### PR TITLE
Add flake8 check to Travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,22 @@ language: python
 python:
   - 3.5
   - 3.6
+env:
+  - RUN_PEP8=0
+  - RUN_PEP8=1
+matrix:
+  exclude:
+    - python: 3.5
+      env: RUN_PEP8=1
+  allow_failures:
+    - env: RUN_PEP8=1
 install:
   - pip install .
 script:
   - pip install pint
   - nosetests
+  - |
+    if [[ "${RUN_PEP8}" == "1" ]]; then
+      pip install flake8
+      flake8
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
   - |
     if [[ "${RUN_PEP8}" == "1" ]]; then
       pip install flake8
-      flake8
+      flake8 --statistics
     fi


### PR DESCRIPTION
Add an additional optional flake8 run to the list of Travis CI builds.
This test is allowed to fail without breaking the build.