### PR TITLE
Make sure HIASI is always sorted in time

### DIFF
--- a/typhon/datasets/tovs.py
+++ b/typhon/datasets/tovs.py
@@ -2123,7 +2123,7 @@ class HIASI(TOVSCollocatedDataset, dataset.NetCDFDataset, dataset.MultiFileDatas
         MM["time"] = M["mon_time"].astype("M8[s]")
         for f in M.dtype.names:
             MM[f][...] = M[f][...]
-        return MM
+        return MM[numpy.argsort(MM["time"])]
 
     def combine(self, M, other_obj, *args, **kwargs):
         MM = super().combine(M, other_obj, *args, col_field="mon_column", **kwargs)


### PR DESCRIPTION
Make sure array returned by HIASI reader (Vijus collocated dataset) is
always sorted in time, otherwise code elsewhere in typhon will complain
and raise an exception (because elsewhere yet, sorted in time is assumed).