### PR TITLE
Migrate to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 install:
   - pip install .[tests]
 script:
-  - nosetests
+  - pytest
   - |
     if [[ "${RUN_PEP8}" == "1" ]]; then
       pip install flake8

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ home directory. That way, local changes to the package are directly available
 in the current environment.
 
 ## Testing
-Typhon contains a simple testing framework using [Nosetests]. It is good
+Typhon contains a simple testing framework using [pytest]. It is good
 practice to write code for all your functions and classes. Those tests may not
 be too extensive but should cover the basic use cases to ensure correct
 behavior through further development of the package.
 
 Tests can be run on the command line...
 ```bash
-$ nosetests typhon
+$ pytest --pyargs typhon
 ```
 or using the Python interpreter:
 ```python
@@ -63,4 +63,4 @@ Kindly note that bleeding edge features might not be covered.
 
 [Sphinx]: http://www.sphinx-doc.org
 [Anaconda]: https://www.continuum.io/downloads
-[Nosetests]: http://nose.readthedocs.io/
+[pytest]: https://docs.pytest.org/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ in the current environment.
 
 ## Testing
 Typhon contains a simple testing framework using [pytest]. It is good
-practice to write code for all your functions and classes. Those tests may not
+practice to write tests for all your functions and classes. Those tests may not
 be too extensive but should cover the basic use cases to ensure correct
 behavior through further development of the package.
 

--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -26,6 +26,20 @@ possible implications with other parts of the project should be addressed.
 .. _`CSI`: https://standards.mousepawmedia.com/csi.html
 .. _`blog post`: https://dev.to/andreasklinger/comments-explain-why-not-what-and-2-more-rules-on-writing-good-comments
 
+Testing
+-------
+
+It is good practice to write tests for all your functions and classes. Those
+tests may not be too extensive but should cover the basic use cases to ensure
+correct behavior through further development of the package.
+
+The Typhon testing framework is using `pytest`_.  You can run the tests from
+the command line using::
+
+    pytest --pyargs typhon
+
+.. _`pytest`: https://docs.pytest.org/en/latest/
+
 Documentation Style
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@
 universal=1
 
 [aliases]
-test=nosetests  # Use nosetests as default to run tests.
+test=pytest  # Use pytest to run tests.

--- a/setup.py
+++ b/setup.py
@@ -97,10 +97,14 @@ setup(
             'pint',
         ],
         'tests': [
-            'nose>=1.3.0',
+            'pytest',
             'pint',
         ],
     },
+
+    # Additional requirements to make `$ python setup.py test` work.
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -24,14 +24,9 @@ if not __TYPHON_SETUP__:
     from . import trees
     from . import utils
 
-    def _runtest():
-        """Run all tests."""
-        from os.path import dirname
-        from sys import argv
-        import matplotlib
-        matplotlib.use('Agg')
-        import nose
-        loader = nose.loader.TestLoader(workingDir=dirname(__file__))
-        return nose.run(argv=[argv[0]], testLoader=loader)
 
-    test = _runtest
+    def test():
+        """Use pytest to collect and run all tests in typhon.tests."""
+        import pytest
+
+        return pytest.main(['--pyargs', 'typhon.tests'])

--- a/typhon/tests/arts/test_arts.py
+++ b/typhon/tests/arts/test_arts.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
-
 """Testing the functions in typhon.arts.
 """
-
-import unittest
 import shutil
+
+import pytest
 
 from typhon import arts
 
 
-class TestPlots(object):
+class TestPlots:
     """Testing the plot functions."""
-    # TODO: Currently issue with ipython not displaying it as skipped
-    @unittest.skipIf(not shutil.which('arts'), 'arts not in PATH')
+    @pytest.mark.skipif(not shutil.which('arts'), reason='arts not in PATH')
     def test_run_arts(self):
         """Test ARTS system call.
 

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -1,11 +1,9 @@
 # -*- encoding: utf-8 -*-
-
-import numpy as np
 import os
 from tempfile import mkstemp
 
+import numpy as np
 import pytest
-from nose.tools import raises
 
 from typhon.arts import griddedfield, xml
 
@@ -26,7 +24,7 @@ def _create_tensor(n):
     return np.arange(2 ** n).reshape(2 * np.ones(n).astype(int))
 
 
-class TestGriddedFieldUsage():
+class TestGriddedFieldUsage:
     ref_dir = os.path.join(os.path.dirname(__file__), "reference", "")
 
     def test_check_init(self):
@@ -43,14 +41,15 @@ class TestGriddedFieldUsage():
         gf3.data = np.ones((5, 5, 1))
         assert gf3.check_dimension() is True
 
-    @raises(Exception)
     def test_check_dimension2(self):
         """Test if grid and data dimension agree (negative)."""
         gf3 = griddedfield.GriddedField3()
         gf3.grids = [np.arange(5), np.arange(5), []]
         gf3.gridnames = ["A", "B", "C"]
-        gf3.data = np.ones((5, 5))
-        gf3.check_dimension()
+
+        # It shold not be allowed to set a Matrix as data in a GriddedField3.
+        with pytest.raises(TypeError):
+            gf3.data = np.ones((5, 5))
 
     def test_data(self):
         """Test setting and getting of data. """
@@ -137,8 +136,8 @@ class TestGriddedFieldUsage():
     def test_get(self):
         """Test the get method for named fields."""
         gf1 = griddedfield.GriddedField1(
-            grids = [['foo', 'bar']],
-            data = np.array([42, 13]),
+            grids=[['foo', 'bar']],
+            data=np.array([42, 13]),
         )
 
         assert gf1.get('foo') == np.array([42])
@@ -146,8 +145,8 @@ class TestGriddedFieldUsage():
     def test_get_default(self):
         """Test the GriddedField.get() behavior for non-existing fieldnames."""
         gf1 = griddedfield.GriddedField1(
-            grids = [['dummy']],
-            data = np.array([0]),
+            grids=[['dummy']],
+            data=np.array([0]),
         )
 
         # Return given default, if a name is not existing.
@@ -159,26 +158,25 @@ class TestGriddedFieldUsage():
     def test_get_keepdims(self):
         """Test the dimension handling of the GriddedField.get()."""
         gf1 = griddedfield.GriddedField1(
-            grids = [['foo', 'bar']],
-            data = np.array([42, 13]),
+            grids=[['foo', 'bar']],
+            data=np.array([42, 13]),
         )
 
         assert gf1.get('foo').shape == (1,)
         assert gf1.get('foo', keep_dims=False).shape == tuple()
 
-    @raises(TypeError )
     def test_get_nofieldnames(self):
         """Test behavior if first grids is not ArrayOfString."""
         gf1 = griddedfield.GriddedField1(
-            grids = [[0]],
-            data = np.array([0]),
+            grids=[[0]],
+            data=np.array([0]),
         )
 
-        # This line should raise a TypeError.
-        gf1.get(0)
+        with pytest.raises(TypeError):
+            gf1.get(0)
 
 
-class TestGriddedFieldLoad():
+class TestGriddedFieldLoad:
     ref_dir = os.path.join(os.path.dirname(__file__), "reference", "")
 
     def test_load_data(self):

--- a/typhon/tests/arts/test_workspace.py
+++ b/typhon/tests/arts/test_workspace.py
@@ -1,16 +1,18 @@
+# -*- encoding: utf-8 -*-
 import numpy as np
-import unittest
+import pytest
 
 try:
     from typhon.arts.workspace import Workspace
-    skip_arts_tests = False
 except:
     skip_arts_tests = True
+else:
+    skip_arts_tests = False
 
 
-@unittest.skipIf(skip_arts_tests, 'ARTS library not available')
-class TestWorkspace(unittest.TestCase):
-    def setUp(self):
+@pytest.mark.skipif(skip_arts_tests, reason='ARTS library not available')
+class TestWorkspace:
+    def setup_method(self):
         """This ensures a new Workspace for every test."""
         self.ws = Workspace()
 

--- a/typhon/tests/arts/xml/load_arts_xml_data.py
+++ b/typhon/tests/arts/xml/load_arts_xml_data.py
@@ -1,32 +1,30 @@
-# -*- encoding: utf-8 -*-
-
+"""Special test case which tries to load all files in ARTS XML data."""
 import os
 
+import pytest
+
 from typhon.arts import xml
+from typhon import environment
 
 
-# Try to load all XML files in ARTS_DATA_PATH.
-#
-# Search for XML files in ARTS_DATA_PATH. If files are found, try to load
-# them. It is just checked, if xml.load runs without exception.
-#
-# Notes:
-#   This is not a docstring to ensure readble output in nosetests.
-data_path = os.getenv('ARTS_DATA_PATH')
+def collect_xml_files():
+    """Collect all XML files in the ARTS XML data tree."""
+    for d in environment.ARTS_DATA_PATH.split(os.path.pathsep):
+        for root, _, filenames in os.walk(d):
+            for filename in filenames:
+                if filename.endswith(('.xml', '.xml.gz')):
+                    yield os.path.join(root, filename)
 
 
-def test_load_arts_xml_data():
-    if data_path:
-        for d in data_path.split(os.path.pathsep):
-            for root, _, filenames in os.walk(d):
-                for filename in filenames:
-                    if filename.endswith(('.xml', '.xml.gz')):
-                        yield _load_xml, os.path.join(root, filename)
-    else:
-        raise Exception('ARTS_DATA_PATH is not set.')
+@pytest.mark.slow
+@pytest.mark.skipif(environment.ARTS_DATA_PATH is None,
+                    reason='ARTS_DATA_PATH not set.')
+@pytest.mark.parametrize('xmlfile', collect_xml_files())
+def test_load_arts_xml_data(xmlfile):
+    """Try to load all XML files in ARTS_DATA_PATH.
 
-
-def _load_xml(f):
-    """Load a given XML file."""
-    xml.load(f)
+    Search for XML files in ARTS_DATA_PATH. If files are found, try to load
+    them. It is just checked, if xml.load runs without exception.
+    """
+    xml.load(xmlfile)
     pass

--- a/typhon/tests/arts/xml/test_matpack_types.py
+++ b/typhon/tests/arts/xml/test_matpack_types.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
-
 """Testing the basic ARTS XML functions
 
 This module provides basic functions to test the reading and writing
 of ARTS XML files.
 """
-
 import os
 from tempfile import mkstemp
 
@@ -44,7 +42,8 @@ def _create_complex_tensor(n):
         np.ndarray: n-dimensional tensor
 
     """
-    return np.arange(2 ** n, dtype=np.complex128).reshape(2 * np.ones(n).astype(int))
+    return np.arange(2 ** n,
+                     dtype=np.complex128).reshape(2 * np.ones(n).astype(int))
 
 
 def _create_empty_tensor(n):
@@ -62,7 +61,7 @@ def _create_empty_tensor(n):
     return np.ndarray((0,) * n)
 
 
-class TestLoad(object):
+class TestLoad:
     """Testing the ARTS XML reading functions.
 
     This class provides functions to test the reading of XML files. For this
@@ -143,7 +142,7 @@ class TestLoad(object):
         assert np.array_equal(test_data, reference)
 
 
-class TestSave():
+class TestSave:
     """Testing the ARTS XML saving functions.
 
     This class provides functions to test the saving of XML files. Data is

--- a/typhon/tests/arts/xml/test_matpack_types.py
+++ b/typhon/tests/arts/xml/test_matpack_types.py
@@ -6,12 +6,11 @@ This module provides basic functions to test the reading and writing
 of ARTS XML files.
 """
 
-import unittest
 import os
 from tempfile import mkstemp
 
 import numpy as np
-from nose.tools import (raises, with_setup)
+import pytest
 
 from typhon.arts import xml
 
@@ -97,10 +96,16 @@ class TestLoad(object):
         test_data = xml.load(self.ref_dir + 'matrix.xml')
         assert np.array_equal(test_data, reference)
 
-    def test_load_tensor(self):
-        """Load reference XML files for different Tensor types."""
-        for n in range(3, 8):
-            yield self._load_tensor, n
+    @pytest.mark.parametrize('n', range(3, 8))
+    def test_load_tensor(self, n):
+        """Load tensor of dimension n and compare data to reference.
+
+        Args:
+            n (int): number of dimensions
+        """
+        reference = _create_tensor(n)
+        test_data = xml.load(self.ref_dir + 'tensor{}.xml'.format(n))
+        assert np.array_equal(test_data, reference)
 
     def test_load_arrayofindex(self):
         """Load reference XML file for ARTS type ArrayOfIndex."""
@@ -137,17 +142,6 @@ class TestLoad(object):
         test_data = xml.load(self.ref_dir + 'arrayofindex-comment.xml')
         assert np.array_equal(test_data, reference)
 
-    def _load_tensor(self, n):
-        """Load tensor of dimension n and compare data to reference.
-
-        Args:
-            n (int): number of dimensions
-
-        """
-        reference = _create_tensor(n)
-        test_data = xml.load(self.ref_dir + 'tensor{}.xml'.format(n))
-        assert np.array_equal(test_data, reference)
-
 
 class TestSave():
     """Testing the ARTS XML saving functions.
@@ -161,11 +155,11 @@ class TestSave():
         other function.
 
     """
-    def setUp(self):
+    def setup_method(self):
         """Create a temporary file."""
         _, self.f = mkstemp()
 
-    def tearDown(self):
+    def teardown_method(self):
         """Delete temporary file."""
         for f in [self.f, self.f + '.bin']:
             if os.path.isfile(f):
@@ -250,24 +244,6 @@ class TestSave():
         test_data = xml.load(self.f)
         assert np.array_equal(test_data, reference)
 
-    # TODO: Test generators are incompatible with the basic unittests.
-    def test_save_empty_tensor(self):
-        """Save different empty Tensor types to file, read and verify."""
-        for n in range(3, 8):
-            yield self._save_empty_tensor, n
-
-    # TODO: Test generators are incompatible with the basic unittests.
-    def test_save_tensor(self):
-        """Save different Tensor types to file, read and verify."""
-        for n in range(3, 8):
-            yield self._save_tensor, n
-
-    # TODO: Test generators are incompatible with the basic unittests.
-    def test_save_tensor_binary(self):
-        """Save different Tensor types to file, read and verify."""
-        for n in range(3, 8):
-            yield self._save_tensor, n, 'binary'
-
     def test_save_arrayofindex(self):
         """Save ArrayOfIndex to file, read it and compare the results."""
         reference = [1., 2., 3.]
@@ -305,30 +281,34 @@ class TestSave():
 
         assert np.array_equal(ref, xml.load(f))
 
-    @raises(Exception)
     def test_save_binary_gzip(self):
         """Check for exception when attempting to write zipped binary file."""
         f = self.f + '.gz'
         ref = np.arange(10)
 
-        xml.save(ref, f, format='binary')
+        with pytest.raises(Exception):
+            xml.save(ref, f, format='binary')
 
-    def _save_tensor(self, n, format='ascii'):
+    @pytest.mark.parametrize('n', range(3, 8))
+    @pytest.mark.parametrize('fileformat', ['ascii', 'binary'])
+    def test_save_load_tensor(self, n, fileformat):
         """Save tensor of dimension n to file, read it and compare data to
         reference.
 
         Args:
             n (int): number of dimensions
+            fileformat (str): 'ascii' or 'binary'.
 
         """
         reference = _create_tensor(n)
-        xml.save(reference, self.f, format=format)
+        xml.save(reference, self.f, format=fileformat)
         test_data = xml.load(self.f)
         assert np.array_equal(test_data, reference)
 
-    def _save_empty_tensor(self, n):
-        """Save empty tensor of dimension n to file, read it and compare data to
-        reference.
+    @pytest.mark.parametrize('n', range(3, 8))
+    def test_save_empty_tensor(self, n):
+        """Save empty tensor of dimension n to file, read it and compare data
+        to reference.
 
         Args:
             n (int): number of dimensions

--- a/typhon/tests/arts/xml/test_xml.py
+++ b/typhon/tests/arts/xml/test_xml.py
@@ -4,12 +4,12 @@
 from os.path import (dirname, join)
 
 import numpy as np
-from nose.tools import raises
+import pytest
 
 from typhon.arts import xml
 
 
-class TestXML(object):
+class TestXML:
     """Testing high-level functionality in typhon.arts.xml."""
     ref_dir = join(dirname(__file__), "reference")
 
@@ -20,8 +20,9 @@ class TestXML(object):
 
         assert np.allclose(t['vector'], ref)
 
-    @raises(KeyError)
     def test_load_directory_exclude(self):
         """Test excluding files when loading directory content."""
         t = xml.load_directory(self.ref_dir, exclude=['vector.xml'])
-        t['vector']
+
+        with pytest.raises(KeyError):
+            t['vector']

--- a/typhon/tests/math/test_math.py
+++ b/typhon/tests/math/test_math.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
-
 """Testing the basic mathematical functions.
 """
-
 import numpy as np
 
-from nose.tools import raises
+import pytest
 
 from typhon import math
 
 
-class TestCommon(object):
+class TestCommon:
     """Testing common mathematical functions."""
     def test_integrate_column(self):
         """Test numerical intergration of array elements.
@@ -74,12 +72,12 @@ class TestCommon(object):
 
         assert(np.allclose(t, ref))
 
-    @raises(ValueError)
     def test_squeezable_logspace_fixpointbounds(self):
         """Test ValueError if fixpoint is out of bounds."""
-        math.squeezable_logspace(100, 1, fixpoint=1.1)
+        with pytest.raises(ValueError):
+            math.squeezable_logspace(100, 1, fixpoint=1.1)
 
-    @raises(ValueError)
     def test_squeezable_logspace_squeezebounds(self):
         """Test ValueError if squeeze is out of bounds."""
-        math.squeezable_logspace(100, 1, squeeze=2.01)
+        with pytest.raises(ValueError):
+            math.squeezable_logspace(100, 1, squeeze=2.01)

--- a/typhon/tests/physics/test_physics.py
+++ b/typhon/tests/physics/test_physics.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
-
 """Testing the functions in typhon.physics.
 """
-
 import numpy as np
 
 from typhon import physics
 
 
-class TestEM(object):
+class TestEM:
     """Testing the typhon.physics.em functions."""
     def test_planck(self):
         """Test calculation of Planck black body radiation."""
@@ -95,7 +93,7 @@ class TestEM(object):
         assert x == 0.01
 
 
-class TestThermodynamics(object):
+class TestThermodynamics:
     """Testing the typhon.physics.thermodynamics functions."""
     def test_e_eq_ice_mk(self):
         """Test calculation of equilibrium water vapor pressure over ice."""

--- a/typhon/tests/plots/test_colors.py
+++ b/typhon/tests/plots/test_colors.py
@@ -1,27 +1,25 @@
 # -*- coding: utf-8 -*-
-
 """Testing the functions in typhon.plots.colors.
 """
-
 import filecmp
+import os
+from tempfile import mkstemp
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os
-import unittest
-from tempfile import mkstemp
 
 from typhon.plots import colors
 
 
-class TestColors(unittest.TestCase):
+class TestColors:
     """Testing the cm functions."""
     ref_dir = os.path.join(os.path.dirname(__file__), "reference", "")
 
-    def setUp(self):
+    def setup_method(self):
         """Create a temporary file."""
         _, self.f = mkstemp()
 
-    def tearDown(self):
+    def teardown_method(self):
         """Delete temporary file."""
         os.remove(self.f)
 

--- a/typhon/tests/plots/test_plots.py
+++ b/typhon/tests/plots/test_plots.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
-
 """Testing the functions in typhon.plots.
 """
-
 import os
 
 from typhon import plots
 
 
-class TestPlots(object):
+class TestPlots:
     """Testing the plot functions."""
     def test_figsize(self):
         """Test golden ratio for figures sizes."""

--- a/typhon/tests/test_atmosphere.py
+++ b/typhon/tests/test_atmosphere.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
-
 """Testing the functions in typhon.atmosphere.
 """
-
 import numpy as np
 
 from typhon import atmosphere
 
 
-class TestAtmosphere(object):
+class TestAtmosphere:
     """Testing the atmosphere functions."""
     def test_iwv(self):
         """Test the IWV calculation."""

--- a/typhon/tests/test_geodesy.py
+++ b/typhon/tests/test_geodesy.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
-
 """Testing the basic geodetic functions.
 """
-
 import numpy as np
 
 from typhon import constants
 from typhon import geodesy
 
 
-class TestGeodesy(object):
+class TestGeodesy:
     """Testing the geodetic functions."""
     def test_ellipsoidmodels(self):
         """Check ellipsoidmodels for valid excentricities."""

--- a/typhon/tests/test_geographical.py
+++ b/typhon/tests/test_geographical.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
-
 """Testing the functions in typhon.geographical.
 """
-
 import numpy as np
 
 from typhon import geographical
 
 
-class TestGeographical(object):
+class TestGeographical:
     """Testing the geographical functions."""
     def test_area_weighted_mean(self):
         """Test calculation of area weighted mean."""

--- a/typhon/tests/utils/test_latex.py
+++ b/typhon/tests/utils/test_latex.py
@@ -1,26 +1,24 @@
 # -*- coding: utf-8 -*-
-
 """Testing the functions in typhon.latex.
 """
-
-from tempfile import mkstemp
 import filecmp
-import numpy as np
 import os
-import unittest
+from tempfile import mkstemp
+
+import numpy as np
 
 from typhon import latex
 
 
-class TestLaTeX(unittest.TestCase):
+class TestLaTeX:
     """Testing the latex functions."""
     ref_dir = os.path.join(os.path.dirname(__file__), "reference", "")
 
-    def setUp(self):
+    def setup_method(self):
         """Create a temporary file."""
         _, self.f = mkstemp()
 
-    def tearDown(self):
+    def teardown_method(self):
         """Delete temporary file."""
         os.remove(self.f)
 

--- a/typhon/tests/utils/test_utils.py
+++ b/typhon/tests/utils/test_utils.py
@@ -1,18 +1,15 @@
 # -*- coding: utf-8 -*-
-
 """Testing the functions in typhon.utils.
 """
-
 import warnings
 
-from nose.tools import raises
+import pytest
 
 from typhon import utils
 
 
 class TestUtils():
     """Testing the typhon.utils functions."""
-    @raises(DeprecationWarning)
     def test_deprecated(self):
         """Test deprecation warning."""
         @utils.deprecated
@@ -21,9 +18,10 @@ class TestUtils():
 
         with warnings.catch_warnings():
             warnings.simplefilter('error')
-            func()
+            with pytest.raises(DeprecationWarning):
+                func()
 
-    @raises(Exception)
     def test_image2mpeg(self):
         """Test the behavior when no files are found."""
-        utils.image2mpeg(glob='', outfile='foo.mp4')
+        with pytest.raises(Exception):
+            utils.image2mpeg(glob='', outfile='foo.mp4')


### PR DESCRIPTION
This closes #27.

Convert the whole testing framework to `pytest`. This includes:
* Replacing all occurrences of `nose` and `unittest` by `pytest` for consistency.
* Adapting `setuptools` and Travis CI configuration.
* Updating information in `README.md` and add paragraph to developer documentation.

Cheers,
Lukas