### PR TITLE
Added a FIDUCEO contribution notice for my contributions

### DIFF
--- a/typhon/datasets/__init__.py
+++ b/typhon/datasets/__init__.py
@@ -7,4 +7,12 @@ reading routines.
 To implement a new reading routine, subclass one of the datasets here.
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 from . import dataset

--- a/typhon/datasets/_tovs_defs.py
+++ b/typhon/datasets/_tovs_defs.py
@@ -1,6 +1,14 @@
 """Relevant definitions for TOVS
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import enum
 import datetime
 import copy

--- a/typhon/datasets/dataset.py
+++ b/typhon/datasets/dataset.py
@@ -1,6 +1,14 @@
 """Module containing classes abstracting datasets
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import abc
 import functools
 import itertools

--- a/typhon/datasets/filters.py
+++ b/typhon/datasets/filters.py
@@ -2,6 +2,14 @@
 
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import abc
 import numpy
 

--- a/typhon/datasets/model.py
+++ b/typhon/datasets/model.py
@@ -1,6 +1,14 @@
 """Datasets for models
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import datetime
 
 import numpy

--- a/typhon/datasets/tovs.py
+++ b/typhon/datasets/tovs.py
@@ -5,6 +5,14 @@ dependency on the pint units library.  Import this module only if you can
 accept such a dependency.
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import sys
 import io
 import tempfile

--- a/typhon/math/array.py
+++ b/typhon/math/array.py
@@ -2,6 +2,14 @@
 
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import numpy
 import scipy.stats
 

--- a/typhon/math/common.py
+++ b/typhon/math/common.py
@@ -5,7 +5,6 @@
 import numpy as np
 import functools
 
-
 __all__ = [
     'integrate_column',
     'interpolate_halflevels',
@@ -104,6 +103,14 @@ def nlogspace(start, stop, num=50):
     """
     return np.exp(np.linspace(np.log(start), np.log(stop), num))
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822.  That specifically applies to the functions
+# promote_maximally and calculate_precisely.
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
 
 def promote_maximally(x):
     """Return copy of x with high precision dtype.

--- a/typhon/math/stats.py
+++ b/typhon/math/stats.py
@@ -2,6 +2,14 @@
 
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import numbers
 
 import numpy

--- a/typhon/physics/metrology.py
+++ b/typhon/physics/metrology.py
@@ -3,6 +3,14 @@
 All functions in this module need sympy.
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import warnings
 
 def express_uncertainty(expr, aliases={}, on_failure="raise",

--- a/typhon/physics/units/common.py
+++ b/typhon/physics/units/common.py
@@ -2,6 +2,14 @@
 """ Common variables to use within the units subpackage.
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 from pint import (UnitRegistry, Context)
 
 __all__ = [

--- a/typhon/physics/units/em.py
+++ b/typhon/physics/units/em.py
@@ -6,6 +6,14 @@ This module imports typhon.physics.units.common and therefore
 has a soft dependency on the pint units library.
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import warnings
 import logging
 

--- a/typhon/physics/units/tools.py
+++ b/typhon/physics/units/tools.py
@@ -1,6 +1,14 @@
 """Miscellaneous unit-aware tools
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 from .common import ureg
 
 import operator

--- a/typhon/plots/plots.py
+++ b/typhon/plots/plots.py
@@ -164,6 +164,14 @@ def heatmap(x, y, bins=20, bisectrix=True, ax=None, **kwargs):
 
     return img
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822.  This specifically applies to the functions
+# scatter_density_plot_matrix and plot_bitfield.
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
 
 def scatter_density_plot_matrix(
         M=None,
@@ -833,6 +841,14 @@ def colored_bars(x, y, c=None, cmap=None, vmin=None, vmax=None, ax=None,
     # Return the ScalarMappable as well as all return values of ``plt.bar``.
     return sm, ret
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822.  This specifically applies to the functions
+# scatter_density_plot_matrix and plot_bitfield.
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
 
 def plot_bitfield(ax, X, Y, bitfield, flag_dict,
         cmap,

--- a/typhon/utils/__init__.py
+++ b/typhon/utils/__init__.py
@@ -299,6 +299,14 @@ def get_time_coordinates(ds):
     time_dims = get_time_dimensions(ds)
     return {k for (k, v) in ds.coords.items() if set(v.dims)&time_dims}
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822.  This specifically applies to the function
+# concat_each_time_coordinate.
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
 
 def concat_each_time_coordinate(*datasets):
     """Concatenate xarray datasets along each time coordinate

--- a/typhon/utils/cache.py
+++ b/typhon/utils/cache.py
@@ -1,6 +1,14 @@
 """Utilities related to caching and memoisation
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import functools
 import logging
 import copy

--- a/typhon/utils/metaclass.py
+++ b/typhon/utils/metaclass.py
@@ -6,6 +6,14 @@ This module contains metaclasses that are used within typhon, but that may
 also be useful for others.
 """
 
+# Any commits made to this module between 2015-05-01 and 2017-03-01
+# by Gerrit Holl are developed for the EC project “Fidelity and
+# Uncertainty in Climate Data Records from Earth Observations (FIDUCEO)”.
+# Grant agreement: 638822
+# 
+# All those contributions are dual-licensed under the MIT license for use
+# in typhon, and the GNU General Public License version 3.
+
 import abc
 
 


### PR DESCRIPTION
For all modules where I made significant contributions, add a FIDUCEO
attribution such as required under EC rules.  In those modules where I
wrote most of the contents, I have added a notice near the top.  In
modules where I have contributed a couple of functions, I have added a
notice near those functions.  In cases where I have made only minor
contributions, I have not added anything.