### PR TITLE
Refactor overlap checking

### DIFF
--- a/typhon/datasets/dataset.py
+++ b/typhon/datasets/dataset.py
@@ -397,7 +397,10 @@ class Dataset(metaclass=utils.metaclass.AbstractDocStringInheritor):
                         "for preceding granule at {:%Y-%m-%d %H:%M:%S}. "
                         "As data are supposed to be sorted in time, this "
                         "probably means duplicate removal is not working "
-                        "as it should. ".format(gran,
+                        "as it should, or you are using an implementation "
+                        "that deliberately leaves duplicates in, and you "
+                        "should be passing enforce_no_duplicates=False to "
+                        "read_period.".format(gran,
                             conttime.astype(datetime.datetime),
                             latest.astype(datetime.datetime)))
                 cont = self._apply_limits_and_filters(cont, limits, filters)

--- a/typhon/datasets/filters.py
+++ b/typhon/datasets/filters.py
@@ -192,9 +192,7 @@ class FirstlineDBFilter(OverlapFilter):
                 bar.finish()
             logging.info("Updated {:d}/{:d} granules".format(count_updated, count_all))
 
-
-
-class FirstlineNoFilter(OverlapFilter):
+class NullLineFilter(OverlapFilter):
     """Do not filter firstlines at all
     """
 

--- a/typhon/datasets/filters.py
+++ b/typhon/datasets/filters.py
@@ -10,8 +10,22 @@
 # All those contributions are dual-licensed under the MIT license for use
 # in typhon, and the GNU General Public License version 3.
 
+import sys
 import abc
+import dbm
+import logging
+import tempfile
+import pathlib
+import shutil
+import datetime
+
 import numpy
+try:
+    import progressbar
+except ImportError:
+    progressbar = None
+
+from . import dataset
 
 class OutlierFilter(metaclass=abc.ABCMeta):
     
@@ -44,3 +58,175 @@ class MEDMAD(OutlierFilter):
                 "input with {ndim:d}>3 dimensions".format(ndim=C.ndim))
         fracdev = ((C - med)/mad)
         return abs(fracdev) > cutoff
+
+
+class OverlapFilter(metaclass=abc.ABCMeta):
+    """Implementations to feed into firstline filtering
+
+    This is used in tovs HIRS reading routine.
+    """
+
+    @abc.abstractmethod
+    def filter_overlap(self, ds, path, header, scanlines):
+        ...
+
+
+class FirstlineDBFilter(OverlapFilter):
+    def __init__(self, ds, granules_firstline_file):
+        self.ds = ds
+        self.granules_firstline_file = granules_firstline_file
+
+    _tmpdir = None
+    _firstline_db = None
+    def filter_overlap(self, path, header, scanlines):
+        """Filter out any scanlines that existed in the previous granule.
+
+        Only works on datasets implementing get_dataname from the header.
+        """
+        dataname = self.ds.get_dataname(header, robust=True)
+        if self._firstline_db is None:
+            try:
+                self._firstline_db = dbm.open(
+                    str(self.granules_firstline_file), "r")
+            except dbm.error as e: # presumably a lock
+                tmpdir = tempfile.TemporaryDirectory()
+                self._tmpdir = tmpdir # should be deleted only when object is
+                tmp_gfl = str(pathlib.Path(tmpdir.name,
+                    self.granules_firstline_file.name))
+                logging.warning("Cannot read GFL DB at {!s}: {!s}, "
+                    "presumably in use, copying to {!s}".format(
+                        self.granules_firstline_file, e.args, tmp_gfl))
+                shutil.copyfile(str(self.granules_firstline_file),
+                    tmp_gfl)
+                self.granules_firstline_file = tmp_gfl
+                self._firstline_db = dbm.open(tmp_gfl)
+        firstline = int(self._firstline_db[dataname])
+        if firstline > scanlines.shape[0]:
+            logging.warning("Full granule {:s} appears contained in previous one. "
+                "Refusing to return any lines.".format(dataname))
+            return scanlines[0:0]
+        return scanlines[scanlines["hrs_scnlin"] > firstline]    
+
+    def update_firstline_db(self, satname=None, start_date=None, end_date=None,
+            overwrite=False):
+        """Create / update the firstline database
+
+        Create or update the database describing for each granule what the
+        first scanline is that doesn't occur in the preceding granule.
+
+        If a granule is entirely contained within the previous one,
+        firstline is set to L+1 where L is the number of lines.
+        """
+        prev_head = prev_line = None
+        satname = satname or self.ds.satname
+        start_date = start_date or self.ds.start_date
+        end_date = end_date or self.ds.end_date
+        if end_date > datetime.datetime.now():
+            end_date = datetime.datetime.now()
+        logging.info("Updating firstline-db {:s} for "
+            "{:%Y-%m-%d}--{:%Y-%m-%d}".format(satname, start_date, end_date))
+        count_updated = count_all = 0
+        with dbm.open(str(self.granules_firstline_file), "c") as gfd:
+            try:
+                bar = progressbar.ProgressBar(max_value=1,
+                    widgets=[progressbar.Bar("=", "[", "]"), " ",
+                        progressbar.Percentage(), ' (',
+                        progressbar.AdaptiveETA(), " -> ",
+                        progressbar.AbsoluteETA(), ') '])
+            except AttributeError:
+                dobar = False
+                bar = None
+                logging.info("If you had the "
+                    "progressbar2 module, you would have gotten a "
+                    "nice progressbar.")
+            else:
+                dobar = sys.stdout.isatty()
+                if dobar:
+                    bar.start()
+                    bar.update(0)
+            for (g_start, gran) in self.ds.find_granules_sorted(start_date, end_date,
+                            return_time=True, satname=satname):
+                try:
+                    (cur_head, cur_line) = self.ds.read(gran,
+                        return_header=True, filter_firstline=False,
+                        apply_scale_factors=False, calibrate=False,
+                        apply_flags=False)
+                    cur_time = self.ds._get_time(cur_line)
+                except (dataset.InvalidFileError,
+                        dataset.InvalidDataError) as exc:
+                    logging.error("Could not read {!s}: {!s}".format(gran, exc))
+                    continue
+                lab = self.ds.get_dataname(cur_head, robust=True)
+                if lab in gfd and not overwrite:
+                    logging.debug("Already present: {:s}".format(lab))
+                elif prev_line is not None:
+                    # what if prev_line is None?  We don't want to define any
+                    # value for the very first granule we process, as we might
+                    # be starting to process in the middle...
+                    if cur_time.max() > prev_time.max():
+                        # Bugfix 2017-01-16: do not get confused between
+                        # the index and the hrs_scnlin field.  So far, I'm using
+                        # the index to set firstline but the hrs_scnlin
+                        # field to apply it.
+                        #first = (cur_time > prev_time[-1]).nonzero()[0][0]
+                        # Bugfix 2017-08-21: instead of taking the last
+                        # time from the previous granule, take the
+                        # maximum; this allows for time sequence errors.
+                        # See #139
+                        first = cur_line["hrs_scnlin"][cur_time > prev_time.max()].min()
+                        logging.debug("{:s}: {:d}".format(lab, first))
+                    else:
+                        first = cur_line["hrs_scnlin"].max()+1
+                        logging.info("{:s}: Fully contained in {:s}!".format(
+                            lab, self.ds.get_dataname(prev_head, robust=True)))
+                    gfd[lab] = str(first)
+                    count_updated += 1
+                prev_line = cur_line.copy()
+                prev_head = cur_head.copy()
+                prev_time = cur_time.copy()
+                if dobar:
+                    bar.update((g_start-start_date)/(end_date-start_date))
+                count_all += 1
+            if dobar:
+                bar.update(1)
+                bar.finish()
+            logging.info("Updated {:d}/{:d} granules".format(count_updated, count_all))
+
+
+
+class FirstlineNoFilter(OverlapFilter):
+    """Do not filter firstlines at all
+    """
+
+    def filter_overlap(self, path, header, scanlines):
+        return scanlines
+
+class BestLineFilter(OverlapFilter):
+    """Choose best between overlaps
+    """
+    def __init__(self, ds):
+        self.ds = ds
+
+    def filter_overlap(self, path, header, scanlines):
+        """Choose best lines in overlap between last/current/next granule
+        """
+
+        # self.read should be using caching already, so no need to keep
+        # track of what I've already read here.  Except that caching only
+        # works if the arguments are identical, which they aren't.
+        # Consider applying caching on a lower level?  But then I need to
+        # store more…
+        prevnext = [
+            self.ds.read(
+                self.ds.find_most_recent_granule_before(
+                    scanlines["time"][idx].astype(datetime.datetime) +
+                        datetime.timedelta(minutes=Δmin)),
+                fields=["hrs_qualind", "hrs_scnlin", "time"],
+                return_header=False,
+                apply_scale_factors=False, calibrate=False, apply_flags=False,
+                filter_firstline=False, apply_filter=False, max_flagged=1.0)
+                        for (idx, Δmin) in [(0, -1), (-1, 1)]]
+
+        #
+        raise NotImplementedError("Not implemented yet beyond this point")
+

--- a/typhon/datasets/tovs.py
+++ b/typhon/datasets/tovs.py
@@ -23,8 +23,6 @@ import gzip
 import shutil
 import abc
 import pathlib
-import dbm
-import contextlib
 import warnings
 import xarray
 import numpy
@@ -170,6 +168,7 @@ class HIRS(dataset.MultiSatelliteDataset, Radiometer, dataset.MultiFileDataset):
 
     max_valid_time_ptp = numpy.timedelta64(3, 'h')
     filter_calibcounts = filter_prttemps = filters.MEDMAD(10)
+    filter_firstline = None
     
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -178,10 +177,10 @@ class HIRS(dataset.MultiSatelliteDataset, Radiometer, dataset.MultiFileDataset):
         if not self.granules_firstline_file.is_absolute():
             self.granules_firstline_file = self.basedir.joinpath(
                 self.granules_firstline_file)
+        self.filter_firstline = filters.FirstlineDBFilter(
+            self, self.granules_firstline_file)
         if self.satname is not None:
             (self.start_date, self.end_date) = _tovs_defs.HIRS_periods[self.satname]
-#        self.granules_firstline_db = dbm.open(
-#            str(self.granules_firstline_file), "c")
         # set here so inheriting classes can extend
         self.temperature_fields = {"iwt", "ict", "fwh", "scanmirror", "primtlscp",
             "sectlscp", "baseplate", "elec", "patch_full", "scanmotor", "fwm",
@@ -193,7 +192,7 @@ class HIRS(dataset.MultiSatelliteDataset, Radiometer, dataset.MultiFileDataset):
                     apply_scale_factors=True, calibrate=True,
                     apply_flags=True,
                     radiance_units="si",
-                    filter_firstline="first",
+                    filter_firstline=filter_firstline,
                     apply_filter=True,
                     max_flagged=0.5):
         if path.endswith(".gz"):
@@ -229,24 +228,21 @@ class HIRS(dataset.MultiSatelliteDataset, Radiometer, dataset.MultiFileDataset):
         # being removed.  This means counting changes, which means the
         # counting-based removal of overlap scanlines will be buggy
         # (see FCDR_HIRS#139 and FCDR_HIRS#141).  Remove overlaps already now.
-        if filter_firstline:
-            try:
-                scanlines = self.filter_overlap(path, header, scanlines,
-                    method=filter_firstline)
-            except KeyError as e:
+        try:
+            scanlines = self.filter_firstline.filter_overlap(
+                path, header, scanlines)
+        except KeyError as e:
                 raise dataset.InvalidFileError(
                     "Unable to filter firstline: {:s}".format(e.args[0])) from e
-            if scanlines.shape[0] < 2:
-                raise dataset.InvalidFileError(
-                    "After filtering firstline, only "
-                    "{shape:d}/{n_lines:d} lines are left. "
-                    "This either means the granule is entirely contained "
-                    "in the previous one, or the previous granule "
-                    "contains time outliers that cause the current one "
-                    "to be mistaken for such (see #142).".format(
-                        shape=scanlines.shape[0],
-                        n_lines=n_lines))
-            n_lines = scanlines.shape[0]
+        if scanlines.shape[0] < 2:
+            raise dataset.InvalidFileError(
+                "{shape:d}/{n_lines:d} lines are left. "
+                "This either means the granule is entirely contained "
+                "in the previous one, or the previous granule "
+                "contains time outliers that cause the current one "
+                "to be mistaken for such (see #142).".format(
+                    n_lines=n_lines))
+        n_lines = scanlines.shape[0]
 
         if apply_scale_factors:
             (header, scanlines) = self._apply_scale_factors(header, scanlines)
@@ -409,10 +405,6 @@ class HIRS(dataset.MultiSatelliteDataset, Radiometer, dataset.MultiFileDataset):
                 scanlines = scanlines.data # no ma when no flags
         elif apply_flags:
             raise ValueError("I refuse to apply flags when not calibrating ☹")
-        elif filter_firstline:
-            raise NotImplementedError("Filtering on firstline when not "
-                "calibrating is no longer supported as of 2017-08-21. "
-                "Sorry!")
         else: # i.e. not calibrating
             # FIXME: this violates DRY a bit, as those lines also occur
             # in the If:-block, but hard to do incrementally.  However, I
@@ -447,161 +439,6 @@ class HIRS(dataset.MultiSatelliteDataset, Radiometer, dataset.MultiFileDataset):
             return (M[0], super()._add_pseudo_fields(M[1], pseudo_fields))
         else:
             return super()._add_pseudo_fields(M, pseudo_fields)
-
-    def filter_overlap(self, path, header, scanlines,
-            method="first"):
-        if method == "first":
-            return self.filter_firstline(header, scanlines)
-        elif method == "best":
-            return self.filter_bestline(path, header, scanlines)
-        else:
-            raise ValueError("Unknown overlap filter "
-                "method: {!s}.  Expected 'first' or 'best'.".format(method))
-
-    def filter_bestline(self, path, header, scanlines):
-        """Choose best lines in overlap between last/current/next granule
-        """
-
-        # self.read should be using caching already, so no need to keep
-        # track of what I've already read here.  Except that caching only
-        # works if the arguments are identical, which they aren't.
-        # Consider applying caching on a lower level?  But then I need to
-        # store more…
-        prevnext = [
-            self.read(
-                self.find_most_recent_granule_before(
-                    scanlines["time"][idx].astype(datetime.datetime) +
-                        datetime.timedelta(minutes=Δmin)),
-                fields=["hrs_qualind", "hrs_scnlin", "time"],
-                return_header=False,
-                apply_scale_factors=False, calibrate=False, apply_flags=False,
-                filter_firstline=False, apply_filter=False, max_flagged=1.0)
-                        for (idx, Δmin) in [(0, -1), (-1, 1)]]
-
-        #
-        raise NotImplementedError("Not implemented yet beyond this point")
-
-    _tmpdir = None
-    _firstline_db = None
-    def filter_firstline(self, header, scanlines):
-        """Filter out any scanlines that existed in the previous granule.
-        """
-        dataname = self.get_dataname(header, robust=True)
-#        with contextlib.ExitStack() as stack:
-        if self._firstline_db is None:
-            try:
-    #            gfd = stack.enter_context(
-                self._firstline_db = dbm.open(
-                    str(self.granules_firstline_file), "r")
-            except dbm.error as e: # presumably a lock
-    #                tmpdir = stack.enter_context(
-    #                    tempfile.TemporaryDirectory())
-                tmpdir = tempfile.TemporaryDirectory()
-                self._tmpdir = tmpdir # should be deleted only when object is
-                tmp_gfl = str(pathlib.Path(tmpdir.name,
-                    self.granules_firstline_file.name))
-                logging.warning("Cannot read GFL DB at {!s}: {!s}, "
-                    "presumably in use, copying to {!s}".format(
-                        self.granules_firstline_file, e.args, tmp_gfl))
-                shutil.copyfile(str(self.granules_firstline_file),
-                    tmp_gfl)
-                self.granules_firstline_file = tmp_gfl
-                #self._firstline_db = stack.enter_context(dbm.open(tmp_gfl))
-                self._firstline_db = dbm.open(tmp_gfl)
-    #        with dbm.open(str(self.granules_firstline_file), "r") as gfd:
-        firstline = int(self._firstline_db[dataname])
-        if firstline > scanlines.shape[0]:
-            logging.warning("Full granule {:s} appears contained in previous one. "
-                "Refusing to return any lines.".format(dataname))
-            return scanlines[0:0]
-        return scanlines[scanlines["hrs_scnlin"] > firstline]
-
-    def update_firstline_db(self, satname=None, start_date=None, end_date=None,
-            overwrite=False):
-        """Create / update the firstline database
-
-        Create or update the database describing for each granule what the
-        first scanline is that doesn't occur in the preceding granule.
-
-        If a granule is entirely contained within the previous one,
-        firstline is set to L+1 where L is the number of lines.
-        """
-        prev_head = prev_line = None
-        satname = satname or self.satname
-        start_date = start_date or self.start_date
-        end_date = end_date or self.end_date
-        if end_date > datetime.datetime.now():
-            end_date = datetime.datetime.now()
-        logging.info("Updating firstline-db {:s} for "
-            "{:%Y-%m-%d}--{:%Y-%m-%d}".format(satname, start_date, end_date))
-        count_updated = count_all = 0
-        with dbm.open(str(self.granules_firstline_file), "c") as gfd:
-            try:
-                bar = progressbar.ProgressBar(max_value=1,
-                    widgets=[progressbar.Bar("=", "[", "]"), " ",
-                        progressbar.Percentage(), ' (',
-                        progressbar.AdaptiveETA(), " -> ",
-                        progressbar.AbsoluteETA(), ') '])
-            except AttributeError:
-                dobar = False
-                bar = None
-                logging.info("If you had the "
-                    "progressbar2 module, you would have gotten a "
-                    "nice progressbar.")
-            else:
-                dobar = sys.stdout.isatty()
-                if dobar:
-                    bar.start()
-                    bar.update(0)
-            for (g_start, gran) in self.find_granules_sorted(start_date, end_date,
-                            return_time=True, satname=satname):
-                try:
-                    (cur_head, cur_line) = self.read(gran,
-                        return_header=True, filter_firstline=False,
-                        apply_scale_factors=False, calibrate=False,
-                        apply_flags=False)
-                    cur_time = self._get_time(cur_line)
-                except (dataset.InvalidFileError,
-                        dataset.InvalidDataError) as exc:
-                    logging.error("Could not read {!s}: {!s}".format(gran, exc))
-                    continue
-                lab = self.get_dataname(cur_head, robust=True)
-                if lab in gfd and not overwrite:
-                    logging.debug("Already present: {:s}".format(lab))
-                elif prev_line is not None:
-                    # what if prev_line is None?  We don't want to define any
-                    # value for the very first granule we process, as we might
-                    # be starting to process in the middle...
-                    if cur_time.max() > prev_time.max():
-                        # Bugfix 2017-01-16: do not get confused between
-                        # the index and the hrs_scnlin field.  So far, I'm using
-                        # the index to set firstline but the hrs_scnlin
-                        # field to apply it.
-                        #first = (cur_time > prev_time[-1]).nonzero()[0][0]
-                        # Bugfix 2017-08-21: instead of taking the last
-                        # time from the previous granule, take the
-                        # maximum; this allows for time sequence errors.
-                        # See #139
-                        first = cur_line["hrs_scnlin"][cur_time > prev_time.max()].min()
-                        logging.debug("{:s}: {:d}".format(lab, first))
-                    else:
-                        first = cur_line["hrs_scnlin"].max()+1
-                        logging.info("{:s}: Fully contained in {:s}!".format(
-                            lab, self.get_dataname(prev_head, robust=True)))
-                    gfd[lab] = str(first)
-                    count_updated += 1
-                prev_line = cur_line.copy()
-                prev_head = cur_head.copy()
-                prev_time = cur_time.copy()
-                if dobar:
-                    bar.update((g_start-start_date)/(end_date-start_date))
-                count_all += 1
-            if dobar:
-                bar.update(1)
-                bar.finish()
-            logging.info("Updated {:d}/{:d} granules".format(count_updated, count_all))
-
-
 
     def check_parity(self, counts):
         """Verify parity for counts

--- a/typhon/datasets/tovs.py
+++ b/typhon/datasets/tovs.py
@@ -229,7 +229,7 @@ class HIRS(dataset.MultiSatelliteDataset, Radiometer, dataset.MultiFileDataset):
         # counting-based removal of overlap scanlines will be buggy
         # (see FCDR_HIRS#139 and FCDR_HIRS#141).  Remove overlaps already now.
         try:
-            scanlines = self.filter_firstline.filter_overlap(
+            scanlines = filter_firstline.filter_overlap(
                 path, header, scanlines)
         except KeyError as e:
                 raise dataset.InvalidFileError(


### PR DESCRIPTION
To enable the HIRS FCDR (which depends on typhon) to implement its own overlap filtering without difficult subclassing, refactor overlap filtering to classes in the filter module, based on the compasition over inheritance principle.  Then FCDR_HIRS can fix FIDUCEO/FCDR_HIRS#7 either by adding an
implementation here on within FCDR_HIRS.

NB!  This causes a backward-incompatible change.  HIRS.read argument filter_firstline now wants an object of a class implementing filters.OverlapFilter.  It no longer accepts a string!