### PR TITLE
Reorganise filtering.  Breaks backward compatibility!

### DIFF
--- a/typhon/datasets/model.py
+++ b/typhon/datasets/model.py
@@ -29,11 +29,11 @@ class ERAInterim(dataset.NetCDFDataset, dataset.MultiFileDataset):
     def _read(self, f, *args, **kwargs):
         # may need to convert, but I currently need gg/as which on CEMS is
         # already in converted format, so will assume NetCDF
-        M = super()._read(f, *args,
+        (M, extra) = super()._read(f, *args,
                           pseudo_fields={"time": self._get_time_from_ds},
                           prim="t",
                           **kwargs)
-        return M
+        return (M, extra)
 
     @staticmethod
     def _get_time_from_ds(ds):


### PR DESCRIPTION
Move filtering responsibility from reader to Dataset class

Move the responsibility to apply filters from reading routines, such as
`HIRS._read`, to the `Dataset` class, specifically the `Dataset.read_period`.
This commit breaks backward compatibility:

- `HIRS._read` no longer accepts a `filter_firstline` keyword argument.

- `HIRS._read` no longer accepts a `return_header` keyword argument.  The
  header is now always returned as the SECOND (not first!) argument.

- Any reading routine, including `HIRS._read`, now ALWAYS returns two
  arguments: first the contents of the file to be read, then a dictionary
  (possibly empty) with any additional arguments.

  Before:

  ```
  (head, lines) = hirs.read_period(
        ...,
        return_header=True,
        reader_args=dict(filter_firstline=HIRS.filter_firstline))
  ```

  After:

  ```
  (lines, extra) = hirs.read_period(
        ...,
        orbit_filters=hirs.default_orbit_filters)
  head = extra["header"]
  ```

Overall changes:

* `typhon/datasets/dataset.py`:

  (`Dataset`):

  - New attribute `default_orbit_filters`.  Implementations can add
    filters here that are always expected to be executed.  This is where
    post-orbit or post-period filtering implementations go.  Those should
    follow the protocol from `filters.OrbitFilter`.

  (`Dataset.read_period`):

  - Apply orbit filters: reset each filter when starting, apply the main
    filter method after each orbit, and a finalise method at the end.
    Catch filtering errors through `filter.FilterError`.

* `typhon/datasets/filter.py`:

  (`FilterError`):

  - New class for any exceptions raised when filtering happens, that
    should not block the processing.

  (`OrbitFilter`):

  - Abstract parent of any class implementing filtering on scanlines of
    any kind.

* `typhon/datasets/tovs.py`:

  (`HIRS.__init__`):

  - Make sure we recommend to always use the `FirstlineDB` filter and the other relevant filters (3 so far).

  (`HIRS._read`):

  - Remove return_header argument, always return header (see above)

  - Remove orbit filtering, this is now handled elsewhere (see above).

Other small adaptations to adapt for backward-incompatible changes made as
described.