### PR TITLE
Add environ handler

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@
 import sys
 import os
 
-from typhon.environment import ARTS_BUILD_PATH
+from typhon.environment import environ
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -120,7 +120,7 @@ todo_include_todos = True
 
 # Exclude ARTS Workspace documentation when `ARTS_BUILD_PATH` is not set.
 # Else, the build fails because typhon.arts.workspace can not be imported.
-if ARTS_BUILD_PATH is None:
+if environ.get('ARTS_BUILD_PATH') is None:
     exclude_patterns.append('typhon.arts.workspace.rst')
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/typhon.config.rst
+++ b/doc/typhon.config.rst
@@ -8,5 +8,5 @@ config
 .. autosummary::
    :toctree: generated
 
-   get_config
+   conf
 

--- a/doc/typhon.environment.rst
+++ b/doc/typhon.environment.rst
@@ -1,9 +1,6 @@
-environment
-===========
+environ
+=======
 
 .. automodule:: typhon.environment
 
 .. currentmodule:: typhon.environment
-
-.. autosummary::
-   :toctree: generated

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -23,6 +23,7 @@ if not __TYPHON_SETUP__:
     from . import spectroscopy
     from . import trees
     from . import utils
+    from .environment import environ
 
 
     def test():

--- a/typhon/arts/common.py
+++ b/typhon/arts/common.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess
 
-import typhon.environment as env
+from typhon.environment import environ
 from typhon.arts.griddedfield import GriddedField4
 from typhon.utils import path_append
 
@@ -48,18 +48,18 @@ def run_arts(controlfile=None, arts=None, writetxt=False,
     """
     # If path to the ARTS exectuable is not passed explicitly, construct it
     # from the ARTS_BUILD_PATH. Its actual existence is checked later.
-    if arts is None and env.ARTS_BUILD_PATH is not None:
-        arts = os.path.join(env.ARTS_BUILD_PATH, 'src', 'arts')
+    if arts is None and environ.get('ARTS_BUILD_PATH') is not None:
+        arts = os.path.join(environ['ARTS_BUILD_PATH'], 'src', 'arts')
     # Try 'arts' as a fallback, maybe it is in the user's PATH.
     elif arts is None:
         arts = 'arts'
 
     # Append ARTS_INCLUDE_PATH and ARTS_DATA_PATH to the user's environment.
-    if env.ARTS_INCLUDE_PATH is not None:
-        path_append(env.ARTS_INCLUDE_PATH, path='ARTS_INCLUDE_PATH')
+    if environ.get('ARTS_INCLUDE_PATH') is not None:
+        path_append(environ.get('ARTS_INCLUDE_PATH'), path='ARTS_INCLUDE_PATH')
 
-    if env.ARTS_DATA_PATH is not None:
-        path_append(env.ARTS_DATA_PATH, path='ARTS_DATA_PATH')
+    if environ.get('ARTS_DATA_PATH') is not None:
+        path_append(environ.get('ARTS_DATA_PATH'), path='ARTS_DATA_PATH')
 
     if not shutil.which(arts):
         raise Exception('ARTS executable not found at: {}'.format(arts))

--- a/typhon/arts/workspace/__init__.py
+++ b/typhon/arts/workspace/__init__.py
@@ -88,12 +88,11 @@ numpy.asarray.
 
 """
 
-from os import environ
 from warnings import warn
 
-from typhon.environment import ARTS_BUILD_PATH
+from typhon.environment import environ
 
-if ARTS_BUILD_PATH is None:
+if environ.get('ARTS_BUILD_PATH') is None:
     warn("ARTS_BUILD_PATH environment variable required to locate ARTS API.")
 else:
     from typhon.arts.workspace.workspace import Workspace, arts_agenda

--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -23,7 +23,8 @@ import ctypes as c
 import numpy  as np
 import os
 
-from typhon.environment import ARTS_BUILD_PATH, ARTS_DATA_PATH, ARTS_INCLUDE_PATH
+from typhon.environment import environ
+
 
 ################################################################################
 # Version Requirements
@@ -37,12 +38,13 @@ arts_minimum_revision = 867
 # Load ARTS C API
 ################################################################################
 
-if ARTS_BUILD_PATH is None:
+if environ.get("ARTS_BUILD_PATH") is None:
     raise EnvironmentError("ARTS_BUILD_PATH environment variable required to"
                            + " locate ARTS API.")
 
 try:
-    lib_path = os.path.join(ARTS_BUILD_PATH, "src", "libarts_api.so")
+    lib_path = os.path.join(environ.get("ARTS_BUILD_PATH"), "src",
+                            "libarts_api.so")
     print("Loading ARTS API from: " + lib_path)
     arts_api = c.cdll.LoadLibrary(lib_path)
 except:
@@ -384,12 +386,12 @@ arts_api.method_print_doc.restype  = c.c_char_p
 ################################################################################
 
 try:
-    arts_include_path = ARTS_INCLUDE_PATH.split(":")
+    arts_include_path = environ.get("ARTS_INCLUDE_PATH").split(":")
 except:
     arts_include_path = []
 
 try:
-    arts_data_path = ARTS_DATA_PATH.split(":")
+    arts_data_path = environ.get("ARTS_DATA_PATH").split(":")
 except:
     arts_data_path = []
 

--- a/typhon/config.py
+++ b/typhon/config.py
@@ -11,34 +11,14 @@ variable TYPHONRC.  If this is not set, it will use ~/.typhonrc.
 
 import pathlib
 import os
-import configparser
+from configparser import (ConfigParser, ExtendedInterpolation)
 
 
-class _Configurator(object):
-    def __init__(self):
-        config = configparser.ConfigParser(
-            interpolation=configparser.ExtendedInterpolation())
-        p = pathlib.Path(os.getenv("TYPHONRC", "~/.typhonrc")).expanduser()
-        config.read(str(p))
-        self.config = config
-
-    def __call__(self, arg, section='main'):
-        return self.config.get(section, arg)
-config = _Configurator()
-conf = config.config
+__all__ = [
+    'conf',
+]
 
 
-def get_config(arg, section='main'):
-    """Get value for configuration variable.
-
-    Arguments:
-
-        arg [str]: Name of configuration variable
-
-    Returns:
-
-        Value for configuration variable
-    """
-    confer = _Configurator()
-
-    return confer(arg, section=section)
+conf = ConfigParser(interpolation=ExtendedInterpolation())
+p = pathlib.Path(os.getenv("TYPHONRC", "~/.typhonrc")).expanduser()
+conf.read(str(p))

--- a/typhon/config.py
+++ b/typhon/config.py
@@ -20,5 +20,6 @@ __all__ = [
 
 
 conf = ConfigParser(interpolation=ExtendedInterpolation())
+conf.optionxform = str
 p = pathlib.Path(os.getenv("TYPHONRC", "~/.typhonrc")).expanduser()
 conf.read(str(p))

--- a/typhon/environment.py
+++ b/typhon/environment.py
@@ -43,7 +43,7 @@ for key in ENVIRONMENT:
     # If the key was not found in the process environment,
     # try to get the value from the TYPHONRC configuration file.
     try:
-        value = typhon.config.get_config(key, section='environment')
+        value = typhon.config.conf.get(section='environment', option=key)
     except:
         value = None
     finally:

--- a/typhon/tests/test_environment.py
+++ b/typhon/tests/test_environment.py
@@ -6,33 +6,48 @@ from copy import copy
 
 import pytest
 
-from typhon import environment
+from typhon import environ
+from typhon.config import conf
 
 
 class TestEnvironment:
     """Testing the environment handler."""
     def setup_method(self):
-        """Run all test methods with an empty environment."""
+        """Run all test methods with empty config and environment."""
         self.env = copy(os.environ)
+        self.conf = copy(conf)
+
         os.environ = {}
+        conf.clear()
 
     def teardown_method(self):
-        """Restore old environment."""
+        """Restore config and environment."""
         os.environ = self.env
+        conf = self.conf
 
     def test_get_environment_variables(self):
         """Test if environment variables are considered."""
         os.environ['TYPHON_ENV_TEST'] = 'TEST_VALUE'
 
-        assert environment.environ['TYPHON_ENV_TEST'] == 'TEST_VALUE'
+        assert environ['TYPHON_ENV_TEST'] == 'TEST_VALUE'
 
     def test_set_environment_variables(self):
         """Test if environment variables are updated."""
-        environment.environ['TYPHON_ENV_TEST'] = 'TEST_VALUE'
+        environ['TYPHON_ENV_TEST'] = 'TEST_VALUE'
 
         assert os.environ['TYPHON_ENV_TEST'] == 'TEST_VALUE'
 
     def test_undefined_variable(self):
         """Test behavior for undefined variables."""
         with pytest.raises(KeyError):
-            environment.environ['TYPHON_ENV_TEST']
+            dummy = environ['TYPHON_ENV_TEST']
+
+    def test_membership(self):
+        """Test the membership check."""
+        os.environ['TYPHON_ENV_TEST'] = 'TEST_VALUE'
+
+        assert 'TYPHON_ENV_TEST' in environ
+
+    def test_membership_negative(self):
+        """Test the membership check (negative)."""
+        assert 'TYPHON_ENV_TEST' not in environ

--- a/typhon/tests/test_environment.py
+++ b/typhon/tests/test_environment.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Testing the environment/configuration handler.
+"""
+import os
+from copy import copy
+
+import pytest
+
+from typhon import environment
+
+
+class TestEnvironment:
+    """Testing the environment handler."""
+    def setup_method(self):
+        """Run all test methods with an empty environment."""
+        self.env = copy(os.environ)
+        os.environ = {}
+
+    def teardown_method(self):
+        """Restore old environment."""
+        os.environ = self.env
+
+    def test_get_environment_variables(self):
+        """Test if environment variables are considered."""
+        os.environ['TYPHON_ENV_TEST'] = 'TEST_VALUE'
+
+        assert environment.environ['TYPHON_ENV_TEST'] == 'TEST_VALUE'
+
+    def test_set_environment_variables(self):
+        """Test if environment variables are updated."""
+        environment.environ['TYPHON_ENV_TEST'] = 'TEST_VALUE'
+
+        assert os.environ['TYPHON_ENV_TEST'] == 'TEST_VALUE'
+
+    def test_undefined_variable(self):
+        """Test behavior for undefined variables."""
+        with pytest.raises(KeyError):
+            environment.environ['TYPHON_ENV_TEST']


### PR DESCRIPTION
This closes #33 

I finished the reimplementation of the environment handler.

This introduces a major API change as the module-level constants `ARTS_BUILD_PATH` (...) have been removed. There is a new top-level object `typhon.environ` that maps a variable name to its value in the environment or configuration:

```python
>>>typhon.environ['ARTS_DATA_PATH']
foo
```
##
@gerritholl I simplified the implementation of the `typhon.config` module significantly. Thereby, I removed the `get_config()` function as it was not used in `typhon` and can be replaced by `typhon.config.conf.get()`. Is this fine for you?

The usage of `typhon.config.conf["main"]["tmpdir"]` is still possible, but the mapping is case-sensitive now so `conf["MAIN"]` does not work anymore (because of consistency with environment variables).

I will not merge this PR until your okay :wink:

@simonpf I adapted the few occurrences of environment variables in your API module. As the tests are passing, I hope it works :wink:

Cheers,
Lukas