### PR TITLE
Simplify orbitfilter creation: methods are now optional with defauls

### DIFF
--- a/typhon/datasets/filters.py
+++ b/typhon/datasets/filters.py
@@ -64,7 +64,7 @@ class MEDMAD(OutlierFilter):
         fracdev = ((C - med)/mad)
         return abs(fracdev) > cutoff
 
-class OrbitFilter(metaclass=abc.ABCMeta):
+class OrbitFilter:
     """Generic, abstract class for any kind of filtering.
 
     Implementations of this class are intended to be used between and
@@ -93,17 +93,14 @@ class OrbitFilter(metaclass=abc.ABCMeta):
 
     args_to_reader = {}
 
-    @abc.abstractmethod
     def reset(self):
-        ...
+        pass
 
-    @abc.abstractmethod
     def filter(self, scanlines, **extra):
-        ...
+        return scanlines
 
-    @abc.abstractmethod
     def finalise(self, arr):
-        ...
+        return arr
     
     def __eq__(self, other):
         return self.__dict__ == other.__dict__


### PR DESCRIPTION
Simplify the implementation/creation of orbit filters.  Class is no longer abstract, just implement whatever you want.  The default for each of the methods is to do nothing at all.