### PR TITLE
Make sure to drop coordinates before renaming and reassigning

### DIFF
--- a/typhon/datasets/tovs.py
+++ b/typhon/datasets/tovs.py
@@ -1853,9 +1853,11 @@ class TOVSCollocatedDataset:
             # rename would rename the coordinates, such that matchup_number ends
             # up having the contents of whatever coordinate came last, and
             # the rest vanishes; need to reassign right coordinates after
-            # renaming.
+            # renaming.  As of xarray 0.10, I need to manually drop them
+            # first or xarray will complain that "the new name
+            # 'matchup_count' conflicts"
             timedims = utils.get_time_dimensions(MM)
-            MM = MM.rename(dict.fromkeys(timedims, self.colloc_dim)
+            MM = MM.drop(timedims).rename(dict.fromkeys(timedims, self.colloc_dim)
                 ).assign_coords(
                     **{d: (self.colloc_dim, MM.coords[d].values)
                        for d in utils.get_time_dimensions(MM)},


### PR DESCRIPTION
When combining TOVSCollocatedDataset with additional data from FCDR, I
need to reassign dimensions.  Starting with xarray 0.10, xarray enforces
to not rename dimensions if their coordinates don't match.  Explicitly
drop the coordinates before renaming the dimensions and assigning new
coordinates.