### PR TITLE
Add custom role for ARTS docserver to Sphinx.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,6 +43,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'matplotlib.sphinxext.plot_directive',
+    'typhon.utils.sphinxext',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
+        'docutils',
         'matplotlib>=1.4',
         'netCDF4>=1.1.1',
         'numexpr',

--- a/typhon/arts/catalogues.py
+++ b/typhon/arts/catalogues.py
@@ -22,11 +22,7 @@ __all__ = ['ArrayOfLineRecord',
 
 
 class ArrayOfLineRecord:
-    """Represents an ArrayOfLineRecord object.
-
-    See online ARTS documentation for object details.
-
-    """
+    """Represents an :arts:`ArrayOfLineRecord` object."""
 
     def __init__(self, data=None, version=None):
         self.data = data
@@ -475,13 +471,8 @@ class Sparse(scipy.sparse.csc_matrix):
 
     This class wraps around the SciPy Compressed Sparse Column matrix. The
     usage is exactly the same, but support for reading and writing XML files
-    is added. Also additional attributes were added, which follow the ARTS
-    names.
-
-    See ARTS_ and SciPy_ documentations for more details.
-
-    .. _ARTS: http://arts.mi.uni-hamburg.de/docserver-trunk/groups/Sparse
-    .. _SciPy: http://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csc_matrix.html
+    is added. Also additional attributes were added to map the ARTS
+    implementation of :arts:`Sparse`.
 
     """
     @property

--- a/typhon/plots/plots.py
+++ b/typhon/plots/plots.py
@@ -636,7 +636,7 @@ def channels(met_mm_backend, ylim=None, ax=None, **kwargs):
 
     Parameters:
         met_mm_backend (ndarray): Backend description for meteorological
-            millimeter sensors with passbands. See ARTS_ documentation.
+            millimeter sensors with passbands (:arts:`met_mm_backend`).
         ylim (tuple): A tuple-like container with the lower and upper y-limits
             for the rectangles.
         ax (AxesSubplot): Axes to plot in.
@@ -675,8 +675,6 @@ def channels(met_mm_backend, ylim=None, ax=None, **kwargs):
         ax.set_xlabel('Frequency [GHz]')
 
         plt.show()
-
-    .. _ARTS: http://arts.mi.uni-hamburg.de/docserver-trunk/variables/met_mm_backend
     """
     # TODO: mpl.patch.Patch do not set the axis limits properly. Consider
     # adding a small convenience code to adjust limits automatically.

--- a/typhon/utils/__init__.py
+++ b/typhon/utils/__init__.py
@@ -18,11 +18,14 @@ import numpy as np
 
 from . import cache
 from . import metaclass
+from . import sphinxext
+
 
 __all__ = [
     "cache",
-    "deprecated",
     "metaclass",
+    "sphinxext",
+    "deprecated",
     "extract_block_diag",
     "Timer",
     "path_append",

--- a/typhon/utils/sphinxext.py
+++ b/typhon/utils/sphinxext.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+"""This module contains custom roles to use in Sphinx.
+"""
+from docutils import nodes
+
+
+def setup(app):
+    """Install the extension.
+
+    Parameters:
+        app: Sphinx application context.
+    """
+    app.add_role('arts', arts_docserver_role)
+
+
+def arts_docserver_role(name, rawtext, text, lineno, inliner, options=None,
+                        content=None):
+    """Create a link to ARTS docserver.
+
+    Parameters:
+        name (str): The role name used in the document.
+        rawtext (str): The entire markup snippet, with role.
+        text (str): The text marked with the role.
+        lineno (str): The line number where rawtext appears in the input.
+        inliner (str): The inliner instance that called us.
+        options (dict): Directive options for customization.
+        content (list): The directive content for customization.
+
+    Returns:
+     list, list: Nodes to insert into the document, System messages.
+    """
+    if content is None:
+        content = []
+
+    if options is None:
+        options = {}
+
+    url = 'http://radiativetransfer.org/docserver-trunk/all/{}'.format(text)
+    node = nodes.reference(rawtext, text, refuri=url, **options)
+
+    return [node], []


### PR DESCRIPTION
This closes #32 

Add a text role to sphinx that allows to conveniently link the ARTS docserver.

```rst
You can reference the ARTS docserver entry for the `Vector` group with :arts:`Vector`.
```