### PR TITLE
Sort found files to fix failing test.

### DIFF
--- a/typhon/tests/spareice/test_datasets.py
+++ b/typhon/tests/spareice/test_datasets.py
@@ -93,7 +93,8 @@ class TestDataset:
         )
 
         found_files = list(ds1.find_files("2017-01-01 18:00:00",
-                                          "2017-01-02 08:00:00"))
+                                          "2017-01-02 08:00:00",
+                                          sort=True))
 
         files = [
             [join(self.refdir, '2017/01/01/120000-180000.nc'),


### PR DESCRIPTION
The sort=True option was missing the the find_files call in test_find_files2. This lead to a test failure.