### PR TITLE
Fix bug in xarray floatunification and in testing thereof

### DIFF
--- a/typhon/tests/utils/test_utils.py
+++ b/typhon/tests/utils/test_utils.py
@@ -31,10 +31,19 @@ class TestUtils():
     def test_undo_xarray_floatification(self):
         ds = xarray.Dataset(
             {"a": (["x"], numpy.array([1, 2, 3], dtype="f4")),
-             "b": (["x"], numpy.array([2.0, 3.0, 4.0]))})
+             "b": (["x"], numpy.array([2.0, 3.0, 4.0])),
+             "c": (["x"], numpy.array(["2010-01-01", "2010-01-02",
+                                       "2010-01-03"], dtype="M8"))})
         ds["a"].encoding = {"dtype": numpy.dtype("i4"),
                             "_FillValue": 1234}
+        # c should NOT be converted because it's a time
+        ds["c"].encoding = {"dtype": numpy.dtype("i8"),
+                            "_FillValue": 12345}
         ds2 = utils.undo_xarray_floatification(ds)
+        assert ds is not ds2 # has to be a copy
         assert ds["a"].encoding == ds2["a"].encoding
         assert numpy.allclose(ds["a"], ds2["a"])
         assert ds2["a"].dtype == ds2["a"].encoding["dtype"]
+        assert (ds2["c"] == ds["c"]).all()
+        assert ds2["c"].dtype == ds["c"].dtype
+        assert ds2["b"].dtype == ds["b"].dtype

--- a/typhon/utils/__init__.py
+++ b/typhon/utils/__init__.py
@@ -415,7 +415,8 @@ def undo_xarray_floatification(ds, fields=None):
 
     Parameters:
 
-        ds (xarray.Dataset): xarray dataset to be converted.
+        ds (xarray.Dataset): xarray dataset to be converted.  Will be
+        copied.
 
         fields (Collection or None): Describes what fields shall be
             converted.  If not given or None (default), convert all fields
@@ -429,17 +430,17 @@ def undo_xarray_floatification(ds, fields=None):
 
     to_correct = {k for (k, v) in ds.data_vars.items()
         if v.encoding.get("dtype", np.dtype("O")).kind[0] in "ui" and
-        not v.dtype.kind in "ui"}
+        not v.dtype.kind in "uiMm"} # don't convert datetime/deltas
 
     if fields is not None:
         to_correct &= fields
 
+    ds2 = ds.copy()
     for k in to_correct:
-        enc = ds[k].encoding
-        ds[k] = ds[k].astype(ds[k].encoding["dtype"])
-        ds[k].encoding.update(enc)
+        ds2[k] = ds[k].astype(ds[k].encoding["dtype"])
+        ds2[k].encoding.update(ds[k].encoding)
 
-    return ds
+    return ds2
 
 def image2mpeg(glob, outfile, framerate=12, resolution='1920x1080'):
     """Combine image files to a video using ``ffmpeg``.


### PR DESCRIPTION
This PR fixes a couple of bugs in xarray unfloatification:
- it should not change the original ds, but return a copy; now fixed,
- this means the test was not working at all as it was comparing before and after, but now it tests what it should,
- has more tests now,
- now leaves datetime64 and timedelta64 alone, as it should.