### PR TITLE
Rename ArrayGroup to GroupedArrays in docs.

### DIFF
--- a/doc/typhon.spareice.rst
+++ b/doc/typhon.spareice.rst
@@ -19,7 +19,7 @@ spareice.array
    :toctree: generated
 
    Array
-   ArrayGroup
+   GroupedArrays
 
 spareice.collocations
 =====================


### PR DESCRIPTION
Fixed build error in documentation.