### PR TITLE
Add ARTS verbosity support to Workspace.

### DIFF
--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -32,7 +32,7 @@ from typhon.environment import environ
 
 arts_minimum_major    = 2
 arts_minimum_minor    = 3
-arts_minimum_revision = 898
+arts_minimum_revision = 973
 
 ################################################################################
 # Load ARTS C API

--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -278,7 +278,7 @@ def variable_value_factory(value):
 ################################################################################
 
 # Create ArtsWorkspace and return handle.
-arts_api.create_workspace.argtypes = None
+arts_api.create_workspace.argtypes = [c.c_long, c.c_long]
 arts_api.create_workspace.restype  = c.c_void_p
 
 # Destroy ArtsWorkspace instance from handle.

--- a/typhon/arts/workspace/workspace.py
+++ b/typhon/arts/workspace/workspace.py
@@ -166,20 +166,26 @@ class Workspace:
 
 
     """
-    def __init__(self):
+    def __init__(self, verbosity=1, agenda_verbosity=0):
         """
         The init function just creates an instance of the ArtsWorkspace class of the
         C API and sets the ptr attributed to the returned handle.
 
         It also adds all workspace methods as attributes to the object.
+
+        Parameters:
+            verbosity (int): Verbosity level (0-3), 1 by default
+            agenda_verbosity (int): Verbosity level for agendas (0-3),
+                                    0 by default
         """
 
         self.__dict__["_vars"] = dict()
-        self.ptr     = arts_api.create_workspace()
+        self.ptr = arts_api.create_workspace(verbosity, agenda_verbosity)
         self.workspace_size = arts_api.get_number_of_variables()
         for name in workspace_methods:
             m = workspace_methods[name]
             setattr(self, m.name, WSMCall(self, m))
+        self.verbosityInit()
 
     def __del__(self):
         """


### PR DESCRIPTION
Verbosity can now be set when creating a Workspace:
    
```
from typhon.arts.workspace import Workspace
ws = Workspace(verbosity=2)
```