### PR TITLE
Revise GriddedField interface

### DIFF
--- a/doc/typhon.arts.rst
+++ b/doc/typhon.arts.rst
@@ -8,8 +8,6 @@ arts
 .. autosummary::
    :toctree: generated
 
-   atm_fields_compact_get
-   atm_fields_compact_update
    run_arts
 
 arts.catalogues

--- a/typhon/arts/common.py
+++ b/typhon/arts/common.py
@@ -7,14 +7,11 @@ import shutil
 import subprocess
 
 from typhon.environment import environ
-from typhon.arts.griddedfield import GriddedField4
 from typhon.utils import path_append
 
 
 __all__ = [
     'run_arts',
-    'atm_fields_compact_get',
-    'atm_fields_compact_update',
     ]
 
 
@@ -119,52 +116,3 @@ def run_arts(controlfile=None, arts=None, writetxt=False,
 
     return arts_out(stdout=p.stdout, stderr=p.stderr, retcode=p.returncode)
 
-
-def atm_fields_compact_get(abs_species, gf4):
-    """Extract species from atm_fields_compact.
-
-    Parameters:
-        abs_species (list): Species to extract.
-        gf4 (GriddedField4): GriddedField4.
-
-    Returns:
-        Extracted profiles.
-
-    """
-    if not isinstance(gf4, GriddedField4):
-        raise Exception(
-            'Expected GriddedField4 but got "{}".'.format(type(gf4).__name__))
-
-    if not isinstance(abs_species, list):
-        raise Exception('Absorption species have to be passed as list.')
-
-    vmr_field = gf4.data[[gf4.grids[0].index(s) for s in abs_species]]
-
-    return vmr_field
-
-
-def atm_fields_compact_update(abs_species, gf4, vmr):
-    """Update profile for given species.
-
-    Parameters:
-        abs_species (string): SpeciesTag.
-        gf4 (GriddedField4): GriddedField4.
-        vmr (ndarray): New VMR field.
-
-    Returns:
-        GriddedField4: Updated atm_fields_compact.
-
-    """
-    if not isinstance(gf4, GriddedField4):
-        raise Exception(
-            'Expected GriddedField4 but got "{}".'.format(type(gf4).__name__))
-
-    if not isinstance(abs_species, list):
-        raise Exception('Absorption species have to be passed as list.')
-
-    species_index = [gf4.grids[0].index(s) for s in abs_species]
-    gf4.data[species_index, :, :, :] = vmr
-
-    gf4.check_dimension()
-
-    return gf4

--- a/typhon/arts/griddedfield.py
+++ b/typhon/arts/griddedfield.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import copy
+import numbers
 
 import numpy as np
 from scipy import interpolate
@@ -439,6 +440,28 @@ class GriddedField(object):
                 'Method only works, if the first grid is an "ArrayOfString"')
 
         self.data[[self.grids[0].index(key)]] = data
+
+    def scale(self, key, factor, dtype=float):
+        """Scale data stored in field with given fieldname.
+
+        Notes:
+              This method only works, if the first grid
+              is an :arts:`ArrayOfString`.
+
+        Parameters:
+              key (str): Name of the field to scale.
+              data (float or ndarray): Scale factor.
+              dtype (type): Data type used for typecasting. If the original
+                dtype of ``GriddedField.data`` is ``int``, the data array
+                gets typecasted to prevent messy behaviour when assigning
+                scaled values.
+        """
+        if issubclass(self.data.dtype.type, numbers.Integral):
+            # Typecast integer data arrays to prevent unwanted typecast when
+            # assigning scaled (float) variables back to the (integer) ndarray.
+            self.data = self.data.astype(dtype)
+
+        self.set(key, self.get(key) * factor)
 
     def to_dict(self):
         """Convert GriddedField to dictionary.

--- a/typhon/arts/griddedfield.py
+++ b/typhon/arts/griddedfield.py
@@ -391,10 +391,11 @@ class GriddedField(object):
         return self
 
     def get(self, key, default=None, keep_dims=True):
-        """Return field with given name.
+        """Return data from field with given fieldname.
 
         Notes:
-              This method only works, if the first grid is an "ArrayOfString".
+              This method only works, if the first grid
+              is an :arts:`ArrayOfString`.
 
         Parameters:
               key (str): Name of the field to extract.
@@ -421,6 +422,23 @@ class GriddedField(object):
 
         # Squeeze empty dimensions, if ``keep_dims`` is ``False``.
         return field if keep_dims else field.squeeze()
+
+    def set(self, key, data):
+        """Assign data to field with given fieldname.
+
+        Notes:
+              This method only works, if the first grid
+              is an :arts:`ArrayOfString`.
+
+        Parameters:
+              key (str): Name of the field to extract.
+              data (ndarray): Data array.
+        """
+        if not get_arts_typename(self.grids[0]) == 'ArrayOfString':
+            raise TypeError(
+                'Method only works, if the first grid is an "ArrayOfString"')
+
+        self.data[[self.grids[0].index(key)]] = data
 
     def to_dict(self):
         """Convert GriddedField to dictionary.

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -175,6 +175,17 @@ class TestGriddedFieldUsage:
         with pytest.raises(TypeError):
             gf1.get(0)
 
+    def test_set(self):
+        """Test the set method for named fields."""
+        gf1 = griddedfield.GriddedField1(
+            grids=[['zero', 'one']],
+            data=np.array([0, 0]),
+        )
+
+        gf1.set('one', 1)
+
+        assert gf1.data[1] == np.array([1])
+
 
 class TestGriddedFieldLoad:
     ref_dir = os.path.join(os.path.dirname(__file__), "reference", "")

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -175,6 +175,32 @@ class TestGriddedFieldUsage:
         with pytest.raises(TypeError):
             gf1.get(0)
 
+    def test_scaling(self):
+        """Test the scaling of data in named fields."""
+        gf1 = griddedfield.GriddedField1(
+            grids=[['first_field', 'second_field']],
+            data=np.array([1., 1.]),
+        )
+
+        gf1.scale('second_field', 0.1)
+
+        # Check if values if *only* values of the second fields are scaled.
+        assert gf1.data[0] == np.array([1])
+        assert gf1.data[1] == np.array([0.1])
+
+    def test_integer_scaling(self):
+        """Test the scaling of integer data in named fields."""
+        gf1 = griddedfield.GriddedField1(
+            grids=[['first_field', 'second_field']],
+            data=np.array([1, 1]),
+        )
+
+        gf1.scale('second_field', 0.1)
+
+        # Check if values if *only* values of the second fields are scaled.
+        assert gf1.data[0] == np.array([1])
+        assert gf1.data[1] == np.array([0.1])
+
     def test_set(self):
         """Test the set method for named fields."""
         gf1 = griddedfield.GriddedField1(


### PR DESCRIPTION
I revised the interface to set, get and scale data stored in a `GriddedField`. At the moment, the implementation is tailor-made for [`atm_fields_compact`](http://radiativetransfer.org/docserver-stable/all/atm_fields_compact) which means that the first grid is required to be a string grid (with field names).

```python
# Get the water vapour VMR as ndarray.
h2o_vmr = gf.get('abs_species-H2O')

# Double the water humidity and re-assign it to the GriddedField.
gf.set('abs_species-H2O', h2o * 2)

# Convenience function for simple scaling (combines the steps above).
gf.scale('abs_species-H2O', 2)
```

Cheers,
Lukas