### PR TITLE
Output required ARTS version if api is not found.

### DIFF
--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -50,7 +50,7 @@ try:
 except:
     raise EnvironmentError("Could not find ARTS API in your ARTS build path. "
                            "Did you install it?" + os.linesep +
-                           "Typhon requires ARTS version "
+                           "Typhon requires at least ARTS version "
                            f"{arts_minimum_major}.{arts_minimum_minor}."
                            f"{arts_minimum_revision}")
 

--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -49,7 +49,10 @@ try:
     arts_api = c.cdll.LoadLibrary(lib_path)
 except:
     raise EnvironmentError("Could not find ARTS API in your ARTS build path. "
-                           + "Did you install it?")
+                           "Did you install it?" + os.linesep +
+                           "Typhon requires ARTS version "
+                           f"{arts_minimum_major}.{arts_minimum_minor}."
+                           f"{arts_minimum_revision}")
 
 ################################################################################
 # Version Check


### PR DESCRIPTION
If the ARTS API is not found, let the user know which ARTS version needs to be installed.