### PR TITLE
Add ScalingFormatter.

### DIFF
--- a/doc/typhon.plots.rst
+++ b/doc/typhon.plots.rst
@@ -32,7 +32,10 @@ plots
    profile_p
    profile_p_log
    profile_z
+   ScalingFormatter
    scatter_density_plot_matrix
+   set_xaxis_formatter
+   set_yaxis_formatter
    sorted_legend_handles_labels
    styles
    supcolorbar

--- a/typhon/plots/__init__.py
+++ b/typhon/plots/__init__.py
@@ -6,6 +6,7 @@
 from typhon.plots import cm  # noqa
 from typhon.plots.colors import *  # noqa
 from typhon.plots.common import *  # noqa
+from typhon.plots.formatter import *  # noqa
 from typhon.plots.plots import *  # noqa
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/typhon/plots/formatter.py
+++ b/typhon/plots/formatter.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+"""Custom tick formatter. """
+import matplotlib.pyplot as plt
+from matplotlib.ticker import LogFormatter, FuncFormatter
+
+from typhon import constants
+
+
+__all__ = [
+    'set_xaxis_formatter',
+    'set_yaxis_formatter',
+    'HectoPascalFormatter',
+    'HectoPascalLogFormatter',
+    'ScalingFormatter',
+]
+
+
+def set_xaxis_formatter(formatter, ax=None):
+    """Set given formatter for major and minor xticks."""
+    if ax is None:
+        ax = plt.gca()
+
+    ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.set_minor_formatter(formatter)
+
+
+def set_yaxis_formatter(formatter, ax=None):
+    """Set given formatter for major and minor yticks."""
+    if ax is None:
+        ax = plt.gca()
+
+    ax.yaxis.set_major_formatter(formatter)
+    ax.yaxis.set_minor_formatter(formatter)
+
+
+def ScalingFormatter(scaling=1, fmtstr='{x:g}'):
+    """Provide a ticklabel formatter that applies scaling.
+
+    Parameters:
+        scaling (float or string): Scaling that is applied to all labels.
+            If `str`, try to find corresponding scale in `typhon.constants`.
+        fmtstr (str): Format string used to create label text.
+            The field `x` is replaced with the scaled label value.
+
+    Returns:
+        matplotlib.ticker.FuncFormatter: Formatter.
+
+    Examples:
+
+    .. plot::
+        :include-source:
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+        from typhon.plots import (set_yaxis_formatter, ScalingFormatter)
+
+
+        y = 1e6 * np.random.randn(100)
+
+        fig, ax = plt.subplots()
+        ax.plot(y)
+        ax.set_ylabel('y')
+        ax.set_title('default')
+
+        fig, ax = plt.subplots()
+        ax.plot(y)
+        set_yaxis_formatter(ScalingFormatter(scaling=1e6))
+        ax.set_ylabel('y in millions')
+        ax.set_title('float scaling')
+
+        fig, ax = plt.subplots()
+        ax.plot(y)
+        set_yaxis_formatter(ScalingFormatter(scaling=1e6, fmtstr='{x:g}M'))
+        ax.set_ylabel('y')
+        ax.set_title('float scaling and custom label')
+
+        fig, ax = plt.subplots()
+        ax.plot(y)
+        set_yaxis_formatter(ScalingFormatter(scaling='kilo', fmtstr='{x:g}k'))
+        ax.set_ylabel('y')
+        ax.set_title('string scaling and custom label')
+
+        plt.show()
+
+    """
+    # Try to find string scaling as attributes in `typhon.constants`.
+    if isinstance(scaling, str):
+        scaling = getattr(constants, scaling)
+
+    @FuncFormatter
+    def formatter(x, pos):
+        return fmtstr.format(x=x / scaling)
+
+    return formatter
+
+
+def HectoPascalFormatter():
+    """Creates hectopascal labels for pascal input.
+
+    Note:
+        Simple wrapper for :func:`~typhon.plots.ScalingFormatter`.
+
+    Examples:
+
+    .. plot::
+        :include-source:
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+        import typhon
+        from typhon.plots import (set_yaxis_formatter, HectoPascalFormatter)
+
+
+        p = typhon.math.nlogspace(1000e2, 0.1e2, 50)
+
+        fig, ax = plt.subplots()
+        ax.plot(np.exp(p / p[0]), p)
+        ax.invert_yaxis()
+        set_yaxis_formatter(HectoPascalFormatter())
+
+        plt.show()
+
+    See also:
+            :func:`~typhon.plots.HectoPascalLogFormatter`
+                Creates logarithmic hectopascal labels for pascal input.
+    """
+    return ScalingFormatter('hecto')
+
+
+class HectoPascalLogFormatter(LogFormatter):
+    """Creates logarithmic hectopascal labels for pascal input.
+
+    This class can be used to create axis labels on the hectopascal scale for
+    values plotted in pascals. It is handy in combination with plotting in
+    logscale.
+
+    Examples:
+
+    .. plot::
+        :include-source:
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+        import typhon
+        from typhon.plots import (set_yaxis_formatter, HectoPascalLogFormatter)
+
+
+        p = typhon.math.nlogspace(1000e2, 0.1e2, 50)  # pressue in Pa
+
+        fig, ax = plt.subplots()
+        ax.semilogy(np.exp(p / p[0]), p)
+        ax.invert_yaxis()
+        set_yaxis_formatter(typhon.plots.HectoPascalLogFormatter())
+
+        plt.show()
+
+    See also:
+            :func:`~typhon.plots.HectoPascalFormatter`
+                Creates hectopascal labels for pascal input.
+    """
+    # TODO (lkluft): Hack to preserve automatic toggling to minor ticks for
+    # log-scales introduced in matplotlib 2.0.
+    # Could be replaced with a decent Formatter subclass in the future.
+    def _num_to_string(self, x, vmin, vmax):
+        return '{:g}'.format(x / 100)
+
+

--- a/typhon/plots/plots.py
+++ b/typhon/plots/plots.py
@@ -13,9 +13,10 @@ import numpy as np
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
-from matplotlib.ticker import LogFormatter, FuncFormatter
+from matplotlib.ticker import FuncFormatter
 from matplotlib.cm import get_cmap
 
+from typhon.plots import formatter
 from typhon.math import stats as tpstats
 
 
@@ -23,8 +24,6 @@ __all__ = [
     'plot_distribution_as_percentiles',
     'heatmap',
     'scatter_density_plot_matrix',
-    'HectoPascalFormatter',
-    'HectoPascalLogFormatter',
     'diff_histogram',
     'profile_p',
     'profile_p_log',
@@ -363,80 +362,6 @@ def scatter_density_plot_matrix(
     return f
 
 
-def HectoPascalFormatter():
-    """Creates hectopascal labels for pascal input.
-    
-    Examples:
-        
-    .. plot::
-        :include-source:
-
-        import numpy as np
-        import matplotlib.pyplot as plt
-        import typhon
-
-    
-        p = typhon.math.nlogspace(1000e2, 0.1e2, 50)
-        x = np.exp(p / p[0])
-
-        fig, ax = plt.subplots()
-        ax.plot(x, p)
-        ax.invert_yaxis()
-        ax.yaxis.set_major_formatter(typhon.plots.HectoPascalFormatter())
-        ax.yaxis.set_minor_formatter(typhon.plots.HectoPascalFormatter())
-        
-        plt.show()
-        
-    See also:
-            :func:`~typhon.plots.HectoPascalLogFormatter`
-                Creates logarithmic hectopascal labels for pascal input.
-    """
-    @FuncFormatter
-    def _HectoPascalFormatter(x, pos):
-        return '{:g}'.format(x / 1e2)
-
-    return _HectoPascalFormatter
-
-
-class HectoPascalLogFormatter(LogFormatter):
-    """Creates logarithmic hectopascal labels for pascal input.
-
-    This class can be used to create axis labels on the hectopascal scale for
-    values plotted in pascals. It is handy in combination with plotting in
-    logscale.
-    
-    Examples:
-        
-    .. plot::
-        :include-source:
-
-        import numpy as np
-        import matplotlib.pyplot as plt
-        import typhon
-
-    
-        p = typhon.math.nlogspace(1000e2, 0.1e2, 50)  # pressue in Pa
-        x = np.exp(p / p[0])
-
-        fig, ax = plt.subplots()
-        ax.semilogy(x, p)
-        ax.invert_yaxis()
-        ax.yaxis.set_major_formatter(typhon.plots.HectoPascalLogFormatter())
-        ax.yaxis.set_minor_formatter(typhon.plots.HectoPascalLogFormatter())
-        
-        plt.show()
-        
-    See also:
-            :func:`~typhon.plots.HectoPascalFormatter`
-                Creates hectopascal labels for pascal input.
-    """
-    # TODO (lkluft): This is an easy hack to preserve the automatic toggling of
-    # minor ticks for log-scales introduced in matplotlib 2.0.
-    # Could be replaced with a decent Formatter subclass in the future.
-    def _num_to_string(self, x, vmin, vmax):
-        return '{:g}'.format(x / 1e2)
-
-
 def profile_p(p, x, ax=None, **kwargs):
     """Plot atmospheric profile against pressure in linear space.
 
@@ -481,8 +406,7 @@ def profile_p(p, x, ax=None, **kwargs):
     ax.set_ylim(pmax, pmin)  # implicitly invert yaxis
 
     # Label and format for yaxis.
-    ax.yaxis.set_major_formatter(HectoPascalFormatter())
-    ax.yaxis.set_minor_formatter(HectoPascalFormatter())
+    formatter.set_yaxis_formatter(formatter.HectoPascalFormatter())
     if ax.is_first_col():
         ax.set_ylabel('Pressure [hPa]')
 
@@ -534,8 +458,7 @@ def profile_p_log(p, x, ax=None, **kwargs):
     ret = profile_p(p, x, ax=ax, **kwargs)
 
     # Set logarithmic scale.
-    ax.yaxis.set_major_formatter(HectoPascalLogFormatter())
-    ax.yaxis.set_minor_formatter(HectoPascalLogFormatter())
+    formatter.set_yaxis_formatter(formatter.HectoPascalLogFormatter())
 
     return ret
 
@@ -589,9 +512,7 @@ def profile_z(z, x, ax=None, **kwargs):
     # Actual plot.
     ret = ax.plot(x, z, **kwargs)
 
-    km_formatter = FuncFormatter(lambda n, pos: '{:g}'.format(n / 1000.))
-    ax.yaxis.set_major_formatter(km_formatter)
-    ax.yaxis.set_minor_formatter(km_formatter)
+    formatter.set_yaxis_formatter(formatter.ScalingFormatter('kilo', '{x:g}'))
 
     return ret
 

--- a/typhon/plots/plots.py
+++ b/typhon/plots/plots.py
@@ -406,7 +406,7 @@ def profile_p(p, x, ax=None, **kwargs):
     ax.set_ylim(pmax, pmin)  # implicitly invert yaxis
 
     # Label and format for yaxis.
-    formatter.set_yaxis_formatter(formatter.HectoPascalFormatter())
+    formatter.set_yaxis_formatter(formatter.HectoPascalFormatter(), ax=ax)
     if ax.is_first_col():
         ax.set_ylabel('Pressure [hPa]')
 
@@ -458,7 +458,7 @@ def profile_p_log(p, x, ax=None, **kwargs):
     ret = profile_p(p, x, ax=ax, **kwargs)
 
     # Set logarithmic scale.
-    formatter.set_yaxis_formatter(formatter.HectoPascalLogFormatter())
+    formatter.set_yaxis_formatter(formatter.HectoPascalLogFormatter(), ax=ax)
 
     return ret
 
@@ -512,7 +512,8 @@ def profile_z(z, x, ax=None, **kwargs):
     # Actual plot.
     ret = ax.plot(x, z, **kwargs)
 
-    formatter.set_yaxis_formatter(formatter.ScalingFormatter('kilo', '{x:g}'))
+    formatter.set_yaxis_formatter(formatter.ScalingFormatter('kilo', '{x:g}'),
+                                  ax=ax)
 
     return ret
 


### PR DESCRIPTION
Add a new class that provides a convenient way to apply a scaling to
ticklabels. The formatter also allows the user to set a different tick
label format.

In this PR:
* Moved all functions and classes related to formatting to `typhon/plots/formatter.py`
* Introduced new `ScalingFormatter` class
* Make use of `ScalingFormatter` in typhon (e.g. `HectoPascalFormatter` or `plot_profile_z()`)
* Add convenience functions to set major and minor formatter for an axis.

Cheers,
Lukas