### PR TITLE
Add necessary version for xarray dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,10 @@ dependencies:
         - netCDF4>=1.1.1
         - nose>=1.3.0
         - numexpr
-        - numpy>=1.6
+        - numpy>=1.13
         - scikit-learn
         - scipy>=0.15.1
         - setuptools>=0.7.2
-        - xarray
+        - xarray>=0.10.2
         - numba
 


### PR DESCRIPTION
Since commit c6ea042 (merged in #143), UnitsAwareDataArray depends on
xarray.DataArray.__array_ufunc__ (which in turn depends on numpy 1.13 or
newer).  This was merged into xarray in
https://github.com/pydata/xarray/pull/1962 and added to release 0.10.2.
The old UnitsAwareDataArray does not work with xarray>=0.10.2 and the new
one does not work with xarray<=0.10.1.  Therefore, typhon now depends on
xarray>=0.10.2 and numpy>=1.13.

Can @lkluft and @olemke please confirm if they are happy with such recent
dependencies?  numpy 1.13 was released 2017-07-06 and xarray 0.10.2 was
released 2018-03-13.  Both versions are currently available in core conda and
pypi so pip or conda users should not have a practical problem with this, unless
they otherwise have code breakages due to recent numpy or xarray upgrades.