### PR TITLE
Migrate to cartopy

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -117,6 +117,7 @@ Plotting
 
    typhon.plots
    typhon.plots.cm
+   typhon.plots.maps
 
 Retrieval
 ---------

--- a/doc/pyplots/plot_density.py
+++ b/doc/pyplots/plot_density.py
@@ -1,30 +1,42 @@
 # -*- coding: utf-8 -*-
+"""Plot to demonstrate the density colormap. """
 
-"""Plot to demonstrate the density colormap.
-"""
-
-import numpy as np
 import matplotlib.pyplot as plt
-from netCDF4 import Dataset
-from mpl_toolkits.basemap import Basemap
+import netCDF4
+import numpy as np
+import cartopy.crs as ccrs
+from cartopy.mpl.gridliner import (LONGITUDE_FORMATTER, LATITUDE_FORMATTER)
 
-import typhon
+from typhon.plots.maps import get_cfeatures_at_scale
 
 
-nc = Dataset('_data/test_data.nc')
-lon, lat = np.meshgrid(nc.variables['lon'][:], nc.variables['lat'][:])
-vmr = nc.variables['qv'][:]
+# Read air temperature data.
+with netCDF4.Dataset('_data/test_data.nc') as nc:
+    lon, lat = np.meshgrid(nc.variables['lon'][:], nc.variables['lat'][:])
+    h2o = nc.variables['qv'][:]
 
+# Create plot with PlateCarree projection.
 fig, ax = plt.subplots(figsize=(10, 8))
-m = Basemap(projection='cyl', resolution='i',
-            llcrnrlat=47, llcrnrlon=3,
-            urcrnrlat=56, urcrnrlon=16)
-m.drawcoastlines()
-m.drawcountries()
-m.drawmeridians(np.arange(0, 20, 2), labels=[0, 0, 0, 1])
-m.drawparallels(np.arange(45, 60, 2), labels=[1, 0, 0, 0])
-m.pcolormesh(lon, lat, vmr, latlon=True, cmap='density', rasterized=True)
-cb = m.colorbar(label='Water vapor [VMR]')
+ax = plt.axes(projection=ccrs.PlateCarree())
+ax.set_extent([3, 16, 47, 56])
+
+# Add map "features".
+features = get_cfeatures_at_scale(scale='50m')
+ax.add_feature(features.BORDERS)
+ax.add_feature(features.COASTLINE)
+
+# Plot the actual data.
+sm = ax.pcolormesh(lon, lat, h2o,
+                   cmap='density',
+                   rasterized=True,
+                   transform=ccrs.PlateCarree(),
+                   )
+fig.colorbar(sm, label='Water vapor [VMR]', fraction=0.0328, pad=0.02)
+
+# Add coordinate system without drawing gridlines.
+gl = ax.gridlines(draw_labels=True, color='none')
+gl.xformatter, gl.yformatter = LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+gl.xlabels_top = gl.ylabels_right = False
 
 fig.tight_layout()
 plt.show()

--- a/doc/pyplots/plot_density.py
+++ b/doc/pyplots/plot_density.py
@@ -13,7 +13,7 @@ from typhon.plots.maps import get_cfeatures_at_scale
 # Read air temperature data.
 with netCDF4.Dataset('_data/test_data.nc') as nc:
     lon, lat = np.meshgrid(nc.variables['lon'][:], nc.variables['lat'][:])
-    h2o = nc.variables['qv'][:]
+    h2o = nc.variables['qv'][:].astype('float64')
 
 # Create plot with PlateCarree projection.
 fig = plt.figure(figsize=(10, 8))

--- a/doc/pyplots/plot_density.py
+++ b/doc/pyplots/plot_density.py
@@ -16,8 +16,8 @@ with netCDF4.Dataset('_data/test_data.nc') as nc:
     h2o = nc.variables['qv'][:]
 
 # Create plot with PlateCarree projection.
-fig, ax = plt.subplots(figsize=(10, 8))
-ax = plt.axes(projection=ccrs.PlateCarree())
+fig = plt.figure(figsize=(10, 8))
+ax = fig.add_subplot(111, projection=ccrs.PlateCarree())
 ax.set_extent([3, 16, 47, 56])
 
 # Add map "features".

--- a/doc/pyplots/plot_phase.py
+++ b/doc/pyplots/plot_phase.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
+"""Plot to demonstrate the phase colormap. """
 
-"""Plot to demonstrate the phase colormap.
-"""
-
-import numpy as np
 import matplotlib.pyplot as plt
-
-from netCDF4 import Dataset
-from mpl_toolkits.basemap import Basemap
+import netCDF4
+import numpy as np
+import cartopy.crs as ccrs
+from cartopy.mpl.gridliner import (LONGITUDE_FORMATTER, LATITUDE_FORMATTER)
 from matplotlib.ticker import FuncFormatter
 
-import typhon
+from typhon.plots.maps import get_cfeatures_at_scale
 
 
 @FuncFormatter
@@ -19,25 +17,41 @@ def degree_formatter(x, pos):
     return '{:.0f}\N{DEGREE SIGN}'.format(np.rad2deg(x))
 
 
-nc = Dataset('_data/test_data.nc')
-nth = 5
-lon, lat = np.meshgrid(nc.variables['lon'][::nth], nc.variables['lat'][::nth])
-u, v = nc.variables['u'][::nth, ::nth], nc.variables['v'][::nth, ::nth]
+# Read wind data.
+with netCDF4.Dataset('_data/test_data.nc') as nc:
+    nth = 5
+    lon, lat = np.meshgrid(nc.variables['lon'][::nth],
+                           nc.variables['lat'][::nth])
+    u, v = nc.variables['u'][::nth, ::nth], nc.variables['v'][::nth, ::nth]
 
 wdir = np.arctan2(u, v) + np.pi
 
+# Create plot with PlateCarree projection.
 fig, ax = plt.subplots(figsize=(10, 8))
-m = Basemap(projection='cyl', resolution='i',
-            llcrnrlat=47, llcrnrlon=3,
-            urcrnrlat=56, urcrnrlon=16)
-m.drawcoastlines()
-m.drawcountries()
-m.drawmeridians(np.arange(0, 20, 2), labels=[0, 0, 0, 1])
-m.drawparallels(np.arange(45, 60, 2), labels=[1, 0, 0, 0])
-m.quiver(lon, lat, u, v, wdir, cmap=plt.get_cmap('phase', 8), latlon=True)
-# Use our own ticklabel formatter.
-cb = m.colorbar(label='Wind direction', format=degree_formatter)
+ax = plt.axes(projection=ccrs.PlateCarree())
+ax.set_extent([3, 16, 47, 56])
+
+# Add map "features".
+features = get_cfeatures_at_scale(scale='50m')
+ax.add_feature(features.BORDERS)
+ax.add_feature(features.COASTLINE)
+ax.add_feature(features.OCEAN)
+
+# Plot the actual data.
+sm = ax.quiver(lon, lat, u, v, wdir,
+               cmap=plt.get_cmap('phase', 8),
+               transform=ccrs.PlateCarree(),
+               )
+
+# Add custom colorbar for wind directions (e.g. tick format).
+cb = fig.colorbar(sm, label='Wind direction', format=degree_formatter,
+                  fraction=0.0328, pad=0.02)
 cb.set_ticks(np.linspace(0, 2 * np.pi, 9))
+
+# Add coordinate system without drawing gridlines.
+gl = ax.gridlines(draw_labels=True, color='none')
+gl.xformatter, gl.yformatter = LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+gl.xlabels_top = gl.ylabels_right = False
 
 fig.tight_layout()
 plt.show()

--- a/doc/pyplots/plot_phase.py
+++ b/doc/pyplots/plot_phase.py
@@ -27,8 +27,8 @@ with netCDF4.Dataset('_data/test_data.nc') as nc:
 wdir = np.arctan2(u, v) + np.pi
 
 # Create plot with PlateCarree projection.
-fig, ax = plt.subplots(figsize=(10, 8))
-ax = plt.axes(projection=ccrs.PlateCarree())
+fig = plt.figure(figsize=(10, 8))
+ax = fig.add_subplot(111, projection=ccrs.PlateCarree())
 ax.set_extent([3, 16, 47, 56])
 
 # Add map "features".

--- a/doc/pyplots/plot_speed.py
+++ b/doc/pyplots/plot_speed.py
@@ -18,8 +18,8 @@ with netCDF4.Dataset('_data/test_data.nc') as nc:
 wspeed = np.hypot(u, v)
 
 # Create plot with PlateCarree projection.
-fig, ax = plt.subplots(figsize=(10, 8))
-ax = plt.axes(projection=ccrs.Mercator())
+fig = plt.figure(figsize=(10, 8))
+ax = fig.add_subplot(111, projection=ccrs.Mercator())
 ax.set_extent([3, 16, 47, 56])
 
 # Add map "features".

--- a/doc/pyplots/plot_temperature.py
+++ b/doc/pyplots/plot_temperature.py
@@ -16,8 +16,8 @@ with netCDF4.Dataset('_data/test_data.nc') as nc:
     temp = nc.variables['temp'][:]
 
 # Create plot with PlateCarree projection.
-fig, ax = plt.subplots(figsize=(10, 8))
-ax = plt.axes(projection=ccrs.PlateCarree())
+fig = plt.figure(figsize=(10, 8))
+ax = fig.add_subplot(111, projection=ccrs.PlateCarree())
 ax.set_extent([3, 16, 47, 56])
 
 # Add map "features".

--- a/doc/pyplots/plot_velocity.py
+++ b/doc/pyplots/plot_velocity.py
@@ -15,8 +15,8 @@ with netCDF4.Dataset('_data/test_data.nc') as nc:
     v = nc.variables['v'][:]
 
 # Create plot with PlateCarree projection.
-fig, ax = plt.subplots(figsize=(10, 8))
-ax = plt.axes(projection=ccrs.PlateCarree())
+fig = plt.figure(figsize=(10, 8))
+ax = fig.add_subplot(111, projection=ccrs.PlateCarree())
 ax.set_extent([3, 16, 47, 56])
 
 # Add map "features".

--- a/doc/typhon.plots.maps.rst
+++ b/doc/typhon.plots.maps.rst
@@ -1,0 +1,12 @@
+plots.maps (*requires cartopy*)
+===============================
+
+.. automodule:: typhon.plots.maps
+
+.. currentmodule:: typhon.plots.maps
+
+.. autosummary::
+    :toctree: generated
+
+    get_cfeatures_at_scale
+    worldmap

--- a/doc/typhon.plots.rst
+++ b/doc/typhon.plots.rst
@@ -21,6 +21,7 @@ plots
    colors2cmap
    figsize
    get_available_styles
+   get_cfeatures_at_scale
    get_subplot_arrangement
    heatmap
    HectoPascalFormatter
@@ -40,6 +41,7 @@ plots
    sorted_legend_handles_labels
    styles
    supcolorbar
+   worldmap
 
 Typhon style sheet
 ^^^^^^^^^^^^^^^^^^

--- a/doc/typhon.plots.rst
+++ b/doc/typhon.plots.rst
@@ -21,7 +21,6 @@ plots
    colors2cmap
    figsize
    get_available_styles
-   get_cfeatures_at_scale
    get_subplot_arrangement
    heatmap
    HectoPascalFormatter
@@ -41,7 +40,6 @@ plots
    sorted_legend_handles_labels
    styles
    supcolorbar
-   worldmap
 
 Typhon style sheet
 ^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
         'docs': [
-            'basemap',
             'pint',
         ],
         'tests': [

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
+        'cartopy',
         'docutils',
         'matplotlib>=1.4',
         'netCDF4>=1.1.1',

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'cartopy',
         'docutils',
         'matplotlib>=1.4',
         'netCDF4>=1.1.1',
@@ -111,6 +110,7 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
         'docs': [
+            'cartopy',
             'pint',
         ],
         'tests': [

--- a/typhon/plots/__init__.py
+++ b/typhon/plots/__init__.py
@@ -7,6 +7,7 @@ from typhon.plots import cm  # noqa
 from typhon.plots.colors import *  # noqa
 from typhon.plots.common import *  # noqa
 from typhon.plots.formatter import *  # noqa
+from typhon.plots.maps import *  # noqa
 from typhon.plots.plots import *  # noqa
 from typhon.plots.arts_lookup import *  # noqa
 

--- a/typhon/plots/__init__.py
+++ b/typhon/plots/__init__.py
@@ -7,8 +7,11 @@ from typhon.plots import cm  # noqa
 from typhon.plots.colors import *  # noqa
 from typhon.plots.common import *  # noqa
 from typhon.plots.formatter import *  # noqa
-from typhon.plots.maps import *  # noqa
 from typhon.plots.plots import *  # noqa
 from typhon.plots.arts_lookup import *  # noqa
+try:
+    from typhon.plots.maps import *  # noqa
+except ImportError:
+    pass
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/typhon/plots/maps.py
+++ b/typhon/plots/maps.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Functions related to plotting maps. """
+import cartopy.crs as ccrs
+from matplotlib import pyplot as plt
+
+
+__all__ = [
+    'worldmap',
+]
+
+
+def worldmap(lat, lon, var=None, fig=None, ax=None, projection=None,
+             bg=False, **kwargs):
+    """Plots the track of a variable on a worldmap.
+
+    Args:
+        lat: Array of latitudes.
+        lon: Array of longitudes.
+        var: Additional array for the variable to plot. If given,
+            the track changes the color according to a color map.
+        fig: A matplotlib figure object. If not given, the current
+            figure is used.
+        ax: A matplotlib axis object. If not given, a new axis
+            object will be created in the current figure.
+        projection: If no axis is given, specify here the cartopy projection.
+        bg: If true, a background image will be drawn.
+        **kwargs:
+
+    Returns:
+        Axis and scatter plot objects.
+    """
+    # Default keyword arguments to pass to hist2d().
+    kwargs_defaults = {
+        "cmap": "qualitative1",
+        "s": 1,
+    }
+    kwargs_defaults.update(kwargs)
+
+    if fig is None:
+        fig = plt.gcf()
+
+    if projection is None:
+        if ax is None:
+
+            projection = ccrs.PlateCarree()
+        else:
+            projection = ax.projection
+
+    if ax is None:
+        ax = fig.add_subplot(111, projection=projection)
+
+    if bg:
+        ax.stock_img()
+
+    # It is counter-intuitive but if we want to plot our data with normal
+    # latitudes and longitudes, we always have to set the transform to
+    # PlateCarree (see https://github.com/SciTools/cartopy/issues/911)
+    if var is None:
+        scatter_plot = ax.scatter(
+            lon, lat, transform=ccrs.PlateCarree(), **kwargs_defaults)
+    else:
+        scatter_plot = ax.scatter(
+            lon, lat, c=var, transform=ccrs.PlateCarree(), **kwargs_defaults)
+        ax.colorbar(scatter_plot)
+
+    return ax, scatter_plot

--- a/typhon/plots/maps.py
+++ b/typhon/plots/maps.py
@@ -2,9 +2,14 @@
 """Functions related to plotting maps. """
 from collections import namedtuple
 
-import cartopy.crs as ccrs
-from cartopy.feature import NaturalEarthFeature, COLORS
-from matplotlib import pyplot as plt
+try:
+    import cartopy.crs as ccrs
+    from cartopy.feature import NaturalEarthFeature, COLORS
+except ImportError:
+    raise ImportError('You have to install `cartopy` to use functions '
+                      'located in `typhon.plots.maps`.')
+else:
+    from matplotlib import pyplot as plt
 
 
 __all__ = [

--- a/typhon/plots/maps.py
+++ b/typhon/plots/maps.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """Functions related to plotting maps. """
+from collections import namedtuple
+
 import cartopy.crs as ccrs
+from cartopy.feature import NaturalEarthFeature, COLORS
 from matplotlib import pyplot as plt
 
 
 __all__ = [
     'worldmap',
+    'get_cfeatures_at_scale',
 ]
 
 
@@ -64,3 +68,97 @@ def worldmap(lat, lon, var=None, fig=None, ax=None, projection=None,
         ax.colorbar(scatter_plot)
 
     return ax, scatter_plot
+
+
+def get_cfeatures_at_scale(scale='110m'):
+    """Return a collection of `NaturalEarthFeature` at given scale.
+
+    Parameters:
+        scale (str): The dataset scale, i.e. one of ‘10m’, ‘50m’,
+            or ‘110m’. Corresponding to 1:10,000,000, 1:50,000,000,
+            and 1:110,000,000 respectively.
+
+    Returns:
+        collections.namedtuple:
+            Collection of :class:`~cartopy.feature.NaturalEarthFeature`
+
+    Examples:
+        >>> features = get_cfeatures_at_scale('50m')
+        >>> print(features.COASTLINE.scale)
+        '50m'
+
+    """
+    d = {}
+
+    d['BORDERS'] = NaturalEarthFeature(
+        category='cultural',
+        name='admin_0_boundary_lines_land',
+        scale=scale,
+        edgecolor='black',
+        facecolor='none',
+    )
+
+    d['STATES'] = NaturalEarthFeature(
+        category='cultural',
+        name='admin_1_states_provinces_lakes',
+        scale=scale,
+        edgecolor='black',
+        facecolor='none',
+    )
+
+    d['COASTLINE'] = NaturalEarthFeature(
+        category='physical',
+        name='coastline',
+        scale=scale,
+        edgecolor='black',
+        facecolor='none',
+    )
+
+    d['LAKES'] = NaturalEarthFeature(
+        category='physical',
+        name='lakes',
+        scale=scale,
+        edgecolor='face',
+        facecolor=COLORS['water'],
+    )
+
+    d['LAND'] = NaturalEarthFeature(
+        category='physical',
+        name='land',
+        scale=scale,
+        edgecolor='face',
+        facecolor=COLORS['land'],
+        zorder=-1,
+    )
+
+    d['OCEAN'] = NaturalEarthFeature(
+        category='physical',
+        name='ocean',
+        scale=scale,
+        edgecolor='face',
+        facecolor=COLORS['water'],
+        zorder=-1,
+    )
+
+    d['RIVERS'] = NaturalEarthFeature(
+        category='physical',
+        name='rivers_lake_centerlines',
+        scale=scale,
+        edgecolor=COLORS['water'],
+        facecolor='none',
+    )
+
+    NaturalEarthFeatures = namedtuple(
+        typename='NaturalEarthFeatures',
+        field_names=(
+            'BORDERS',
+            'STATES',
+            'COASTLINE',
+            'LAKES',
+            'LAND',
+            'OCEAN',
+            'RIVERS',
+        ),
+    )
+
+    return NaturalEarthFeatures(**d)

--- a/typhon/plots/plots.py
+++ b/typhon/plots/plots.py
@@ -10,7 +10,6 @@ import math
 import warnings
 
 import numpy as np
-from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 from matplotlib.ticker import FuncFormatter
@@ -33,7 +32,6 @@ __all__ = [
     'channels',
     'colored_bars',
     'plot_bitfield',
-    'worldmap',
 ]
 
 
@@ -726,64 +724,6 @@ def channels(met_mm_backend, ylim=None, ax=None, **kwargs):
         patches.append(plot_band(center, width, ymin, ymax))
 
     return patches
-
-
-def worldmap(lat, lon, var=None, fig=None, ax=None, projection=None,
-             bg=False, **kwargs):
-    """Plots the track of a variable on a worldmap.
-
-    Args:
-        lat: Array of latitudes.
-        lon: Array of longitudes.
-        var: Additional array for the variable to plot. If given,
-            the track changes the color according to a color map.
-        fig: A matplotlib figure object. If not given, the current
-            figure is used.
-        ax: A matplotlib axis object. If not given, a new axis
-            object will be created in the current figure.
-        projection: If no axis is given, specify here the cartopy projection.
-        bg: If true, a background image will be drawn.
-        **kwargs:
-
-    Returns:
-        Axis and scatter plot objects.
-    """
-    import cartopy.crs as ccrs  # noqa
-
-    # Default keyword arguments to pass to hist2d().
-    kwargs_defaults = {
-        "cmap": "qualitative1",
-        "s": 1,
-    }
-    kwargs_defaults.update(kwargs)
-
-    if fig is None:
-        fig = plt.gcf()
-
-    if projection is None:
-        if ax is None:
-            projection = ccrs.PlateCarree()
-        else:
-            projection = ax.projection
-
-    if ax is None:
-        ax = fig.add_subplot(111, projection=projection)
-
-    if bg:
-        ax.stock_img()
-
-    # It is counter-intuitive but if we want to plot our data with normal
-    # latitudes and longitudes, we always have to set the transform to
-    # PlateCarree (see https://github.com/SciTools/cartopy/issues/911)
-    if var is None:
-        scatter_plot = ax.scatter(
-            lon, lat, transform=ccrs.PlateCarree(), **kwargs_defaults)
-    else:
-        scatter_plot = ax.scatter(
-            lon, lat, c=var, transform=ccrs.PlateCarree(), **kwargs_defaults)
-        fig.colorbar(scatter_plot)
-
-    return ax, scatter_plot
 
 
 def colored_bars(x, y, c=None, cmap=None, vmin=None, vmax=None, ax=None,


### PR DESCRIPTION
This PR adresses #140:
* Convert all colormap examples from basemap to cartopy.
* Adapt Travis CI build to setup an Anaconda environment to allow an easy usage of cartopy.
* Move all mapping related functions to own module (with own documentation) and clearly state the soft dependency on `cartopy`.

Cheers,
Lukas