### PR TITLE
Fix metrology bug related to sums

### DIFF
--- a/typhon/physics/metrology.py
+++ b/typhon/physics/metrology.py
@@ -59,7 +59,42 @@ def express_uncertainty(expr, aliases={}, on_failure="raise",
     rv = sympy.sympify(0)
     sensitivities = {}
     components = {}
-    for sym in recursive_args(expr):
+    # the derivative to an indexed value inside a summation needs to be
+    # considered explicitly.  When we have \sum_n=1^N a_n, a naive u(y)
+    # will consider (d/da_n \sum_n=1^N a_n)^2 (u(a_n)^2 = N u(a_n)^2,
+    # which takes a_n out of the summation and is wrong.  It should be
+    # \sum_n=1^N (d/da_n a_n)^2 u(a_n)^2 = \sum_n=1^N u(a_n)^2, i.e., we
+    # need to explicitly take the expression of uncertainty inside the
+    # summation.
+    #
+    # Any other expression with limits that is not a sum, such as a
+    # product, is currently not supported.
+    # Nor are nested sums.
+    for ewl in recursive_args(expr,
+            stop_at=sympy.concrete.expr_with_limits.ExprWithLimits):
+        if isinstance(ewl, sympy.Sum):
+            # FIXME: THIS IS WRONG?  This is correct if and only if the
+            # Sum is at the top-level.  If the sum is inside anything
+            # else, then THIS IS WRONG?  NO IT IS NOT WRONG!  In the
+            # expression of uncertainty we ALWAYS get a summation on the
+            # outside.  But it needs to be squared and all.  Need to
+            # check.  But may not be wrong??
+            rv += sympy.Sum(express_uncertainty(
+                        ewl.args[0], aliases, on_failure,
+                        collect_failures), ewl.args[1])
+            # FIXME: sensitivities and components!
+        else:
+            raise ValueError(f"Failed to express uncertainty in {expr!s}. "
+                "Uncertainty in {ewl!s} not supported.  The "
+                "only expression with limits supported is the summation.")
+    recargs = recursive_args(expr,
+            stop_at=(sympy.Symbol, sympy.Indexed,
+                     sympy.concrete.expr_with_limits.ExprWithLimits))
+    if recargs == set() and expr.args != (): # does not mean uncertainty is zero...!
+        recargs.add(expr) # probably a loose Symbol or Indexed
+    for sym in recargs:
+        if isinstance(sym, sympy.concrete.expr_with_limits.ExprWithLimits):
+            continue # already considered above
         sym = aliases.get(sym, sym)
         try:
             sigma = sympy.diff(expr, sym)
@@ -119,9 +154,12 @@ def recursive_args(expr, stop_at=None, partial_at=None):
             # arg=Sum(T_PRT[n], (n, 0, N)), then arg.args[0]=T_PRT[n],
             # recursive_args(arg.args[0]) = set() (if sympy.Indexed is in
             # stop_at, such as by default), and neither gets added.
+            # We should also make sure that any variable that is summed
+            # over (stored in arg.args[1][0]) is excluded in any case.
             args.update((
                 {arg.args[0]} if isinstance(arg.args[0], stop_at) else set()) |
-                recursive_args(arg.args[0], stop_at=stop_at))
+                (recursive_args(arg.args[0], stop_at=stop_at)
+                 - {arg.args[1][0]}))
         else:
             args.update(recursive_args(arg, stop_at=stop_at))
     return args


### PR DESCRIPTION
Fixed a bug in expression uncertainty related to sums.  Finally decided that summations are simply not supported, because it causes too many headaches.  Instead, the summation must be expanded prior to calling `express_uncertainty`.  However, the expression can still contain `IndexedBase` quantities (like `T_PRT[0, 1]`.  Now, `express_uncertainty` is aware that this is a single unit and will not unpack this into any smaller units.  To this end, `recursive_args` is now `IndexedBase`-aware and excludes from its arguments anything that disappears when the quantity is being summed over.