### PR TITLE
Fix doc build

### DIFF
--- a/doc/typhon.spareice.rst
+++ b/doc/typhon.spareice.rst
@@ -8,4 +8,4 @@ spareice
 .. autosummary::
    :toctree: generated
 
-   Retriever
+   SPAREICE

--- a/typhon/spareice/__init__.py
+++ b/typhon/spareice/__init__.py
@@ -2,7 +2,7 @@
 
 """Implementation of SPARE-ICE
 
-This is a reimplementation of the toolkit developed by Gerit Holl for atmlab.
+This is a reimplementation of the toolkit developed by Gerrit Holl for atmlab.
 
 TODO: Extend documentation and credits.
 """


### PR DESCRIPTION
@JohnMrziglod I replaced the non-existent Retriever class in the .rst file with the SPAREICE class to make the doc build run through.