### PR TITLE
Restructure submodules

### DIFF
--- a/doc/pyplots/plot_difference.py
+++ b/doc/pyplots/plot_difference.py
@@ -6,7 +6,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-from typhon.plots import (figsize, mpl_colors)
+from typhon.plots import (figsize, cmap2rgba)
 
 
 x = np.linspace(0, 2 * np.pi, 500)
@@ -14,7 +14,7 @@ y = np.linspace(0, -1, 500)[:, np.newaxis]
 z = np.sin(x**2) * np.exp(y)
 
 fig, ax = plt.subplots(figsize=figsize(10))
-ax.set_prop_cycle(color=mpl_colors('qualitative1', 7))
+ax.set_prop_cycle(color=cmap2rgba('qualitative1', 7))
 sm = ax.pcolormesh(x, y, z, cmap='difference', rasterized=True)
 fig.colorbar(sm)
 

--- a/doc/pyplots/plot_max-planck.py
+++ b/doc/pyplots/plot_max-planck.py
@@ -6,13 +6,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import norm
 
-from typhon.plots import mpl_colors
+from typhon.plots import cmap2rgba
 
 
 x = np.linspace(-2, 7, 100)
 
 fig, ax = plt.subplots()
-ax.set_prop_cycle(color=mpl_colors('max_planck'))
+ax.set_prop_cycle(color=cmap2rgba('max_planck'))
 for i in range(1, 5):
     ax.fill_between(x, norm.pdf(x, loc=i) / i, edgecolor='black')
 ax.set_ylim(bottom=0)

--- a/doc/pyplots/plot_qualitative1.py
+++ b/doc/pyplots/plot_qualitative1.py
@@ -6,13 +6,13 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-from typhon.plots import (figsize, mpl_colors)
+from typhon.plots import (figsize, cmap2rgba)
 
 
 x = np.linspace(0, 10, 100)
 
 fig, ax = plt.subplots(figsize=figsize(10))
-ax.set_prop_cycle(color=mpl_colors('qualitative1', 7))
+ax.set_prop_cycle(color=cmap2rgba('qualitative1', 7))
 for c in np.arange(1, 8):
     ax.plot(x, (15 + x) * c, linewidth=3)
 ax.set_xlim(x.min(), x.max())

--- a/doc/pyplots/plot_qualitative2.py
+++ b/doc/pyplots/plot_qualitative2.py
@@ -7,14 +7,14 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
-from typhon.plots import (figsize, mpl_colors)
+from typhon.plots import (figsize, cmap2rgba)
 
 
 # Create an iterator to conveniently change the marker in the following plot.
 markers = (m for m in Line2D.filled_markers)
 
 fig, ax = plt.subplots(figsize=figsize(10))
-ax.set_prop_cycle(color=mpl_colors('qualitative2', 7))
+ax.set_prop_cycle(color=cmap2rgba('qualitative2', 7))
 for c in np.arange(7):
     X = np.random.randn(100) / 2
     Y = np.random.randn(100) / 2

--- a/doc/typhon.physics.rst
+++ b/doc/typhon.physics.rst
@@ -14,8 +14,10 @@ physics
    frequency2wavelength
    frequency2wavenumber
    fresnel
+   integrate_water_vapor
    mixing_ratio2specific_humidity
    mixing_ratio2vmr
+   moist_lapse_rate
    planck
    planck_wavelength
    planck_wavenumber
@@ -23,11 +25,14 @@ physics
    radiance2rayleighjeansTb
    rayleighjeans
    rayleighjeans_wavelength
+   relative_humidity2vmr
    snell
    specific_humidity2mixing_ratio
    specific_humidity2vmr
+   standard_atmosphere
    stefan_boltzmann_law
    vmr2mixing_ratio
+   vmr2relative_humidity
    vmr2specific_humidity
    wavelength2frequency
    wavelength2wavenumber

--- a/doc/typhon.plots.rst
+++ b/doc/typhon.plots.rst
@@ -14,6 +14,7 @@ plots
    cmap2c3g
    cmap2cpt
    cmap2ggr
+   cmap2rgba
    cmap2txt
    cmap_from_act
    cmap_from_txt

--- a/typhon/physics/__init__.py
+++ b/typhon/physics/__init__.py
@@ -3,6 +3,7 @@
 """Various physics-related modules."""
 
 from typhon import constants  # noqa
+from typhon.physics.atmosphere import *  # noqa
 from typhon.physics.em import *  # noqa
 from typhon.physics.metrology import *  # noqa
 from typhon.physics.thermodynamics import *  # noqa

--- a/typhon/physics/atmosphere.py
+++ b/typhon/physics/atmosphere.py
@@ -5,24 +5,75 @@
 import numpy as np
 from scipy.interpolate import interp1d
 
-from . import constants
-from . import math
-from .physics import thermodynamics
-
-from typhon.utils import deprecated
+from typhon import constants
+from typhon import math
+from typhon.physics import thermodynamics
 
 
 __all__ = [
-    'iwv',
+    'relative_humidity2vmr',
+    'vmr2relative_humidity',
+    'integrate_water_vapor',
     'moist_lapse_rate',
-    'relative_humidity',
-    'vmr',
     'standard_atmosphere',
 ]
 
 
-@deprecated(new_name='typhon.physics.integrate_water_vapor')
-def iwv(vmr, p, T, z, axis=0):
+def relative_humidity2vmr(RH, p, T):
+    r"""Convert relative humidity into water vapor VMR.
+
+    .. math::
+        VMR = \frac{RH \cdot e_s(T)}{p}
+
+    Parameters:
+        RH (float or ndarray): Relative humidity.
+        p (float or ndarray): Pressue [Pa].
+        T (float or ndarray): Temperature [K].
+
+    Returns:
+        float or ndarray: Volume mixing ratio [unitless].
+
+    See also:
+        :func:`~typhon.physics.vmr2relative_humidity`
+            Complement function (returns RH for given VMR).
+        :func:`~typhon.physics.e_eq_water_mk`
+            Used to calculate the equilibrium water vapor pressure.
+
+    Examples:
+        >>> relative_humidity2vmr(0.75, 101300, 300)
+        0.026185323887350429
+    """
+    return RH * thermodynamics.e_eq_water_mk(T) / p
+
+
+def vmr2relative_humidity(vmr, p, T):
+    r"""Convert water vapor VMR into relative humidity.
+
+    .. math::
+        RH = \frac{VMR \cdot p}{e_s(T)}
+
+    Parameters:
+        vmr (float or ndarray): Volume mixing ratio,
+        p (float or ndarray): Pressure [Pa].
+        T (float or ndarray): Temperature [K].
+
+    Returns:
+        float or ndarray: Relative humiditity [unitless].
+
+    See also:
+        :func:`~typhon.physics.relative_humidity2vmr`
+            Complement function (returns VMR for given RH).
+        :func:`~typhon.physics.e_eq_water_mk`
+            Used to calculate the equilibrium water vapor pressure.
+
+    Examples:
+        >>> vmr2relative_humidity(0.025, 1013e2, 300)
+        0.71604995533615401
+    """
+    return vmr * p / thermodynamics.e_eq_water_mk(T)
+
+
+def integrate_water_vapor(vmr, p, T, z, axis=0):
     """Calculate the integrated water vapor (IWV).
 
     Parameters:
@@ -41,7 +92,6 @@ def iwv(vmr, p, T, z, axis=0):
     return math.integrate_column(vmr * rho, z, axis=axis)
 
 
-@deprecated(new_name='typhon.physics.moist_lapse_rate')
 def moist_lapse_rate(p, T, e_eq=None):
     r"""Calculate the moist-adiabatic temperature lapse rate.
 
@@ -93,63 +143,6 @@ def moist_lapse_rate(p, T, e_eq=None):
     return lapse
 
 
-@deprecated(new_name='typhon.physics.vmr2relative_humidity')
-def relative_humidity(vmr, p, T):
-    r"""Calculate relative humidity (RH).
-
-    .. math::
-        RH = \frac{VMR \cdot p}{e_s(T)}
-
-    Parameters:
-        vmr (float or ndarray): Volume mixing ratio,
-        p (float or ndarray): Pressure [Pa].
-        T (float or ndarray): Temperature [K].
-
-    Returns:
-        float or ndarray: Relative humiditity [unitless].
-
-    See also:
-        :func:`~typhon.atmosphere.vmr`
-            Complement function (returns VMR for given RH).
-        :func:`~typhon.physics.e_eq_water_mk`
-            Used to calculate the equilibrium water vapor pressure.
-
-    Examples:
-        >>> relative_humidity(0.025, 1013e2, 300)
-        0.71604995533615401
-    """
-    return vmr * p / thermodynamics.e_eq_water_mk(T)
-
-
-@deprecated(new_name='typhon.physics.relative_humidity2vmr')
-def vmr(RH, p, T):
-    r"""Calculate the volume mixing ratio (VMR).
-
-    .. math::
-        VMR = \frac{RH \cdot e_s(T)}{p}
-
-    Parameters:
-        RH (float or ndarray): Relative humidity.
-        p (float or ndarray): Pressue [Pa].
-        T (float or ndarray): Temperature [K].
-
-    Returns:
-        float or ndarray: Volume mixing ratio [unitless].
-
-    See also:
-        :func:`~typhon.atmosphere.relative_humidity`
-            Complement function (returns RH for given VMR).
-        :func:`~typhon.physics.e_eq_water_mk`
-            Used to calculate the equilibrium water vapor pressure.
-
-    Examples:
-        >>> vmr(0.75, 101300, 300)
-        0.026185323887350429
-    """
-    return RH * thermodynamics.e_eq_water_mk(T) / p
-
-
-@deprecated(new_name='typhon.physics.standard_atmosphere')
 def standard_atmosphere(z, fill_value='extrapolate'):
     """International Standard Atmosphere (ISA) as a function of height.
 

--- a/typhon/plots/colors.py
+++ b/typhon/plots/colors.py
@@ -10,18 +10,23 @@ from matplotlib.colors import LinearSegmentedColormap
 import numpy as np
 from warnings import warn
 
-__all__ = ['mpl_colors',
-           'colors2cmap',
-           'cmap2txt',
-           'cmap2cpt',
-           'cmap2act',
-           'cmap2c3g',
-           'cmap2ggr',
-           'cmap_from_act',
-           'cmap_from_txt',
-           ]
+from typhon.utils import deprecated
+
+__all__ = [
+    'mpl_colors',
+    'cmap2rgba',
+    'colors2cmap',
+    'cmap2txt',
+    'cmap2cpt',
+    'cmap2act',
+    'cmap2c3g',
+    'cmap2ggr',
+    'cmap_from_act',
+    'cmap_from_txt',
+]
 
 
+@deprecated(new_name='typhon.plots.cmap2rgba')
 def mpl_colors(cmap=None, N=None):
     """Return a list of RGB values.
 
@@ -35,6 +40,34 @@ def mpl_colors(cmap=None, N=None):
 
     Examples:
         >>> mpl_colors('viridis', 5)
+        array([[ 0.267004,  0.004874,  0.329415,  1.      ],
+            [ 0.229739,  0.322361,  0.545706,  1.      ],
+            [ 0.127568,  0.566949,  0.550556,  1.      ],
+            [ 0.369214,  0.788888,  0.382914,  1.      ],
+            [ 0.993248,  0.906157,  0.143936,  1.      ]])
+    """
+    if cmap is None:
+        cmap = plt.rcParams['image.cmap']
+
+    if N is None:
+        N = plt.get_cmap(cmap).N
+
+    return plt.get_cmap(cmap)(np.linspace(0, 1, N))
+
+
+def cmap2rgba(cmap=None, N=None):
+    """Convert a colormap into a list of RGBA values.
+
+    Parameters:
+        cmap (str): Name of a registered colormap.
+        N (int): Number of RGBA-values to return.
+            If ``None`` use the number of colors defined in the colormap.
+
+    Returns:
+        ndarray: RGBA-values.
+
+    Examples:
+        >>> cmap2rgba('viridis', 5)
         array([[ 0.267004,  0.004874,  0.329415,  1.      ],
             [ 0.229739,  0.322361,  0.545706,  1.      ],
             [ 0.127568,  0.566949,  0.550556,  1.      ],
@@ -104,7 +137,7 @@ def cmap2txt(cmap, filename=None, N=None, comments='%'):
         comments (str): Character to start comments with.
 
     """
-    colors = mpl_colors(cmap, N)
+    colors = cmap2rgba(cmap, N)
     header = 'Colormap "{}"'.format(cmap)
 
     if filename is None:
@@ -123,7 +156,7 @@ def cmap2cpt(cmap, filename=None, N=None):
         N (int): Number of colors.
 
     """
-    colors = mpl_colors(cmap, N)
+    colors = cmap2rgba(cmap, N)
     header = ('# GMT palette "{}"\n'
               '# COLOR_MODEL = RGB\n'.format(cmap))
 
@@ -167,7 +200,7 @@ def cmap2act(cmap, filename=None, N=None):
         N = 256
         warn('Maximum number of colors is 256.')
 
-    colors = mpl_colors(cmap, N)[:, :3]
+    colors = cmap2rgba(cmap, N)[:, :3]
 
     rgb = np.zeros(256 * 3 + 2)
     rgb[:colors.size] = (colors.flatten() * 255).astype(np.uint8)
@@ -189,7 +222,7 @@ def cmap2c3g(cmap, filename=None, N=None):
     if filename is None:
         filename = cmap + '.c3g'
 
-    colors = mpl_colors(cmap, N)
+    colors = cmap2rgba(cmap, N)
 
     header = (
         '/*'
@@ -227,7 +260,7 @@ def cmap2ggr(cmap, filename=None, N=None):
     if filename is None:
         filename = cmap + '.ggr'
 
-    colors = mpl_colors(cmap, N)
+    colors = cmap2rgba(cmap, N)
     header = ('GIMP Gradient\n'
               'Name: {}\n'
               '{}\n').format(cmap, len(colors) - 1)

--- a/typhon/tests/physics/test_atmosphere.py
+++ b/typhon/tests/physics/test_atmosphere.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Testing the functions in typhon.atmosphere.
+"""
+import numpy as np
+
+from typhon.physics import atmosphere
+
+
+class TestAtmosphere:
+    """Testing the atmosphere functions."""
+    def test_integrate_water_vapor(self):
+        """Test the IWV calculation."""
+        p = np.linspace(1000, 10, 10)
+        T = 300 * np.ones(p.shape)
+        z = np.linspace(0, 75000, 10)
+        vmr = 0.1 * np.ones(p.shape)
+
+        iwv = atmosphere.integrate_water_vapor(vmr, p, T, z)
+
+        assert np.allclose(iwv, 27.3551036)
+
+    def test_integrate_water_vapor_multi(self):
+        """Test multidimensional IWV calculation."""
+        p = np.linspace(1000, 10, 10)
+        T = 300 * np.ones(p.shape)
+        z = np.linspace(0, 75000, 10)
+        vmr = 0.1 * np.ones((5, *p.shape))
+
+        iwv = atmosphere.integrate_water_vapor(vmr, p, T, z, axis=1)
+
+        assert np.allclose(iwv, np.repeat(27.3551036, 5))
+
+    def test_vmr2relative_humidity(self):
+        """Test conversion from VMR into relative humidity."""
+        rh = atmosphere.vmr2relative_humidity(0.025, 1013e2, 300)
+
+        assert np.allclose(rh, 0.7160499)
+
+    def test_relative_humidity2vmr(self):
+        """Test conversion from relative humidity into VMR."""
+        vmr = atmosphere.relative_humidity2vmr(0.75, 1013e2, 300)
+
+        assert np.allclose(vmr, 0.0261853)
+
+    def test_vmr_rh_conversion(self):
+        """Check the consistency of VMR and relative humidity conversion.
+
+        Converting VMR into relative humidity and back to ensure that both
+        functions yield consistent results.
+        """
+        rh = atmosphere.vmr2relative_humidity(0.025, 1013e2, 300)
+        vmr = atmosphere.relative_humidity2vmr(rh, 1013e2, 300)
+
+        assert np.allclose(vmr, 0.025)
+
+    def test_moist_lapse_rate(self):
+        """Test calculation of moist-adiabatic lapse rate."""
+        gamma = atmosphere.moist_lapse_rate(1000e2, 300)
+
+        assert np.isclose(gamma, 0.00367349)
+
+    def test_standard_atmosphere(self):
+        """Test International Standard Atmosphere."""
+        isa = atmosphere.standard_atmosphere
+
+        assert np.isclose(isa(0), 288.1831)  # Surface temperature
+        assert np.isclose(isa(81e3), 194.5951)  # Test extrapolation
+        # Test call with ndarray.
+        assert np.allclose(isa(np.array([0, 15e3])),
+                           np.array([288.1831, 216.65]))

--- a/typhon/tests/plots/test_colors.py
+++ b/typhon/tests/plots/test_colors.py
@@ -23,6 +23,14 @@ class TestColors:
         """Delete temporary file."""
         os.remove(self.f)
 
+    def test_cmap2rgba(self):
+        """Check colormap to RGB conversion."""
+        ref = np.loadtxt(os.path.join(self.ref_dir, 'viridis.txt'),
+                         comments='%')
+        rgb = colors.cmap2rgba('viridis', 256)[:, :3]  # ignore alpha
+
+        assert np.allclose(ref, rgb)
+
     def test_cmap2cpt(self):
         """Export colormap to cpt file."""
         colors.cmap2cpt('viridis', filename=self.f)


### PR DESCRIPTION
PR summary:
* The `deprecated` decorator allows the user to refer to new functions
* Rename `typhon.plots.mpl_colors` -> `typhon.plots.cmap2rgba` for clearity.
* The module `typhon.atmosphere` is moved to `typhon.physics.atmosphere`.
  While doing so several functions have been renamed:
  `typhon.atmosphere.iwv` -> `typhon.physics.integrate_water_vapor`
 `typhon.atmosphere.vmr` -> `typhon.physics.relative_humidity2vmr`
 `typhon.atmosphere.relative_humidity` -> `typhon.physics.vmr2relative_humidity`

All old functions are still in place and have been given a deprecation warning. They will be removed **immediately** after the next release. So for the stable version they are still around, but not in the development version.

Cheers,
Lukas