### PR TITLE
Add `e_eq` keyword to rel. humidity conversions.

### DIFF
--- a/typhon/physics/atmosphere.py
+++ b/typhon/physics/atmosphere.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-def relative_humidity2vmr(RH, p, T):
+def relative_humidity2vmr(RH, p, T, e_eq=None):
     r"""Convert relative humidity into water vapor VMR.
 
     .. math::
@@ -29,6 +29,11 @@ def relative_humidity2vmr(RH, p, T):
         RH (float or ndarray): Relative humidity.
         p (float or ndarray): Pressue [Pa].
         T (float or ndarray): Temperature [K].
+        e_eq (callable): Function to calculate the equilibrium vapor
+            pressure of water in Pa. The function must implement the
+            signature ``e_eq = f(T)`` where ``T`` is temperature in Kelvin.
+            If ``None`` the function :func:`~typhon.physics.e_eq_water_mk` is
+            used.
 
     Returns:
         float or ndarray: Volume mixing ratio [unitless].
@@ -43,10 +48,13 @@ def relative_humidity2vmr(RH, p, T):
         >>> relative_humidity2vmr(0.75, 101300, 300)
         0.026185323887350429
     """
-    return RH * thermodynamics.e_eq_water_mk(T) / p
+    if e_eq is None:
+        e_eq = thermodynamics.e_eq_water_mk
+
+    return RH * e_eq(T) / p
 
 
-def vmr2relative_humidity(vmr, p, T):
+def vmr2relative_humidity(vmr, p, T, e_eq=None):
     r"""Convert water vapor VMR into relative humidity.
 
     .. math::
@@ -56,9 +64,14 @@ def vmr2relative_humidity(vmr, p, T):
         vmr (float or ndarray): Volume mixing ratio,
         p (float or ndarray): Pressure [Pa].
         T (float or ndarray): Temperature [K].
+        e_eq (callable): Function to calculate the equilibrium vapor
+            pressure of water in Pa. The function must implement the
+            signature ``e_eq = f(T)`` where ``T`` is temperature in Kelvin.
+            If ``None`` the function :func:`~typhon.physics.e_eq_water_mk` is
+            used.
 
     Returns:
-        float or ndarray: Relative humiditity [unitless].
+        float or ndarray: Relative humidity [unitless].
 
     See also:
         :func:`~typhon.physics.relative_humidity2vmr`
@@ -70,7 +83,10 @@ def vmr2relative_humidity(vmr, p, T):
         >>> vmr2relative_humidity(0.025, 1013e2, 300)
         0.71604995533615401
     """
-    return vmr * p / thermodynamics.e_eq_water_mk(T)
+    if e_eq is None:
+        e_eq = thermodynamics.e_eq_water_mk
+
+    return vmr * p / e_eq(T)
 
 
 def integrate_water_vapor(vmr, p, T, z, axis=0):
@@ -104,10 +120,10 @@ def moist_lapse_rate(p, T, e_eq=None):
     Parameters:
         p (float or ndarray): Pressure [Pa].
         T (float or ndarray): Temperature [K].
-        e_eq (callable): Function object which is used to calculate the
-            equilibrium water vapor pressure in Pa. The function must implement
-            the signature ``e_eq = f(T)`` where ``T`` is temperature in Kelvin.
-            If ``None`` the function :func:`typhon.physics.e_eq_water_mk` is
+        e_eq (callable): Function to calculate the equilibrium vapor
+            pressure of water in Pa. The function must implement the
+            signature ``e_eq = f(T)`` where ``T`` is temperature in Kelvin.
+            If ``None`` the function :func:`~typhon.physics.e_eq_water_mk` is
             used.
 
     Returns:

--- a/typhon/physics/thermodynamics.py
+++ b/typhon/physics/thermodynamics.py
@@ -21,22 +21,23 @@ __all__ = [
 
 
 def e_eq_ice_mk(T):
-    r"""Calculate the equilibrium water vapor pressure over ice.
-
-    Equilibrium water vapor pressure over ice using Murphy and Koop 2005
-    parameterization formula.
+    r"""Calculate the equilibrium vapor pressure of water over ice.
 
     .. math::
-        \ln(e_i) = 9.550426
+        \ln(e_\mathrm{ice}) = 9.550426
                    - \frac{5723.265}{T}
                    + 3.53068 \cdot \ln(T)
                    - 0.00728332 \cdot T
 
     Parameters:
-        T (float or ndarray): Temperature in [K].
+        T (float or ndarray): Temperature [K].
 
     Returns:
-        float or ndarray: Equilibrium water vapor pressure over ice in [Pa].
+        float or ndarray: Equilibrium vapor pressure [Pa].
+
+    See also:
+        :func:`~typhon.physics.e_eq_water_mk`
+            Calculate the equilibrium vapor pressure over liquid water.
 
     References:
         Murphy, D. M. and Koop, T. (2005): Review of the vapour pressures of
@@ -55,13 +56,11 @@ def e_eq_ice_mk(T):
 
 
 def e_eq_water_mk(T):
-    r"""Calculate the equilibrium water vapor pressure over water.
-
-    Equilibrium water vapor pressure over water using Murphy and
-    Koop 2005 parameterization formula.
+    r"""Calculate the equilibrium vapor pressure of water over liquid water.
 
     .. math::
-        \ln(e_w) &= 54.842763 - \frac{6763.22}{T} - 4.21 \cdot \ln(T) \\
+        \ln(e_\mathrm{liq}) &=
+                    54.842763 - \frac{6763.22}{T} - 4.21 \cdot \ln(T) \\
                     &+ 0.000367 \cdot T
                     + \tanh \left(0.0415 \cdot (T - 218.8)\right) \\
                     &\cdot \left(53.878 - \frac{1331.22}{T}
@@ -69,10 +68,14 @@ def e_eq_water_mk(T):
                                  + 0.014025 \cdot T \right)
 
     Parameters:
-        T (float or ndarray): Temperature in [K].
+        T (float or ndarray): Temperature [K].
 
     Returns:
-        float or ndarray: Equilibrium water vapor pressure over water in [Pa].
+        float or ndarray: Equilibrium vapor pressure [Pa].
+
+    See also:
+        :func:`~typhon.physics.e_eq_ice_mk`
+            Calculate the equilibrium vapor pressure of water over ice.
 
     References:
         Murphy, D. M. and Koop, T. (2005): Review of the vapour pressures of


### PR DESCRIPTION
The functions `vmr2relative_humidity` and `relative_humidity2vmr` both
accept the keyword `e_eq` which allows the user to pass an alternative
function to calculate the equilibrium vapor pressure of water.

Minor changes to related docstrings.