### PR TITLE
Lazy import of arts_api.

### DIFF
--- a/typhon/arts/covariancematrix.py
+++ b/typhon/arts/covariancematrix.py
@@ -1,7 +1,6 @@
 import numpy as np
 import scipy as sp
 import matplotlib.pyplot as plt
-from typhon.arts.workspace.api import arts_api
 from typhon.arts.catalogues import Sparse
 import ctypes as c
 
@@ -172,6 +171,8 @@ class CovarianceMatrix(object):
 
 
         """
+        from typhon.arts.workspace.api import arts_api
+
         n_blocks = s.dimensions[0]
         n_inv_blocks = s.dimensions[1]
 


### PR DESCRIPTION
* Only import arts_api at the time it is needed to avoid import
  failure at top level if ARTS_BUILD_PATH is not defined.

* Fixes #195.