### PR TITLE
Close file descriptor of temp file.

### DIFF
--- a/typhon/tests/arts/test_covariancematrix.py
+++ b/typhon/tests/arts/test_covariancematrix.py
@@ -15,7 +15,8 @@ class TestCovarianceMatrix:
 
     def setup_method(self):
         # Temporary file
-        _, self.f = mkstemp()
+        fd, self.f = mkstemp()
+        os.close(fd)
 
         # Simple covariance matrix for testing
         b1 = Block(0, 0, 0, 0, False, np.random.normal(size = (10, 10)))

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -289,7 +289,8 @@ class TestGriddedFieldLoad:
 class TestGriddedFieldWrite:
     def setup_method(self):
         """Create a temporary file."""
-        _, self.f = mkstemp()
+        fd, self.f = mkstemp()
+        os.close(fd)
 
     def teardown_method(self):
         """Delete temporary file."""

--- a/typhon/tests/arts/xml/test_matpack_types.py
+++ b/typhon/tests/arts/xml/test_matpack_types.py
@@ -156,7 +156,8 @@ class TestSave:
     """
     def setup_method(self):
         """Create a temporary file."""
-        _, self.f = mkstemp()
+        fd, self.f = mkstemp()
+        os.close(fd)
 
     def teardown_method(self):
         """Delete temporary file."""

--- a/typhon/tests/plots/test_colors.py
+++ b/typhon/tests/plots/test_colors.py
@@ -17,7 +17,8 @@ class TestColors:
 
     def setup_method(self):
         """Create a temporary file."""
-        _, self.f = mkstemp()
+        fd, self.f = mkstemp()
+        os.close(fd)
 
     def teardown_method(self):
         """Delete temporary file."""

--- a/typhon/tests/utils/test_latex.py
+++ b/typhon/tests/utils/test_latex.py
@@ -16,7 +16,8 @@ class TestLaTeX:
 
     def setup_method(self):
         """Create a temporary file."""
-        _, self.f = mkstemp()
+        fd, self.f = mkstemp()
+        os.close(fd)
 
     def teardown_method(self):
         """Delete temporary file."""


### PR DESCRIPTION
We only use mkstemp to get a temporary file name, but it also opens the file,
which we do later ourselves. Since windows does not allow a file be opened
twice for writing, the initial fd has to be closed.