### PR TITLE
Add mailmap.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+Gerrit Holl <gerrit.holl@gmail.com> <g.holl@reading.ac.uk>
+Gerrit Holl <gerrit.holl@gmail.com> <gerrit@aaf1aab0-4228-0410-ad68-8dceda47f409>
+John Mrziglod <mrzo@gmx.de>
+John Mrziglod <mrzo@gmx.de> <jmrziglod@aaf1aab0-4228-0410-ad68-8dceda47f409>
+Lukas Kluft <lukas.kluft@gmail.com> <lkluft@aaf1aab0-4228-0410-ad68-8dceda47f409>
+Oliver Lemke <olemke@gmail.com> <olemke@aaf1aab0-4228-0410-ad68-8dceda47f409>
+Richard Larsson <ric.larsson@gmail.com> <richard@aaf1aab0-4228-0410-ad68-8dceda47f409>
+Robin Ekelund <robin.ekelund@chalmers.se> <rekelund@aaf1aab0-4228-0410-ad68-8dceda47f409>
+Simon Pfreundschuh <simon.pfreundschuh@chalmers.se> <simonpf@aaf1aab0-4228-0410-ad68-8dceda47f409>
+Simon Pfreundschuh <simon.pfreundschuh@chalmers.se> <simonpf@chalmers.se>
+Takayoshi Yamada <yamada.t.bd@m.titech.ac.jp>
+Takayoshi Yamada <yamada.t.bd@m.titech.ac.jp> <35097468+TakayoshiYamada@users.noreply.github.com>
+Theresa Mieslinger <theresa.mieslinger@gmail.com> <[theresa@mieslinger.org]>


### PR DESCRIPTION
For consistent author names in commands such as 'git log
--use-mailmap' or 'git shortlog -s'.