### PR TITLE
Fix temporary files

### DIFF
--- a/typhon/files/utils.py
+++ b/typhon/files/utils.py
@@ -70,9 +70,10 @@ def compress(filename, fmt=None, tmpdir=None):
         yield filename
         return
 
-    with tempfile.NamedTemporaryFile(dir=tmpdir) as tfile:
-        yield tfile.name
-        compress_as(tfile.name, fmt, filename, keep=True)
+    with tempfile.TemporaryDirectory(dir=tmpdir) as tdir:
+        tfile = os.path.join(tdir, 'temp')
+        yield tfile
+        compress_as(tfile, fmt, filename, keep=True)
 
 
 def compress_as(filename, fmt, target=None, keep=True):

--- a/typhon/tests/arts/xml/test_matpack_types.py
+++ b/typhon/tests/arts/xml/test_matpack_types.py
@@ -161,7 +161,7 @@ class TestSave:
 
     def teardown_method(self):
         """Delete temporary file."""
-        for f in [self.f, self.f + '.bin']:
+        for f in [self.f, self.f + '.gz', self.f + '.bin']:
             if os.path.isfile(f):
                 os.remove(f)
 

--- a/typhon/tests/files/handlers/test_netcdf4.py
+++ b/typhon/tests/files/handlers/test_netcdf4.py
@@ -1,8 +1,10 @@
+import os
 import tempfile
 
 import numpy as np
-from typhon.files import NetCDF4
 import xarray as xr
+
+from typhon.files import NetCDF4
 
 
 class TestNetCDF4:
@@ -15,7 +17,8 @@ class TestNetCDF4:
         """
         fh = NetCDF4()
 
-        with tempfile.NamedTemporaryFile() as file:
+        with tempfile.TemporaryDirectory() as tdir:
+            tfile = os.path.join(tdir, 'testfile')
             before = xr.Dataset({
                 "var1": ("dim1", np.arange(5)),
                 "group1/var1": ("group1/dim1", np.arange(5)),
@@ -34,8 +37,8 @@ class TestNetCDF4:
             })
 
             # Save the dataset and load it again:
-            fh.write(before, file.name)
-            after = fh.read(file.name)
+            fh.write(before, tfile)
+            after = fh.read(tfile)
 
             # How it should be after loading:
             check = xr.Dataset({

--- a/typhon/tests/files/test_utils.py
+++ b/typhon/tests/files/test_utils.py
@@ -1,4 +1,5 @@
-from tempfile import gettempdir, NamedTemporaryFile
+import os
+from tempfile import TemporaryDirectory
 
 from typhon.files import compress, decompress
 
@@ -15,33 +16,37 @@ class TestCompression:
             return self.data == file.readline()
 
     def test_compress_decompress_zip(self):
-        with NamedTemporaryFile() as file:
-            with compress(file.name+".zip") as compressed_file:
+        with TemporaryDirectory() as tdir:
+            tfile = os.path.join(tdir, 'testfile')
+            with compress(tfile + ".zip") as compressed_file:
                 self.create_file(compressed_file)
 
-            with decompress(file.name+".zip") as uncompressed_file:
+            with decompress(tfile + ".zip") as uncompressed_file:
                 assert self.check_file(uncompressed_file)
 
     def test_compress_decompress_gzip(self):
-        with NamedTemporaryFile() as file:
-            with compress(file.name+".gz") as compressed_file:
+        with TemporaryDirectory() as tdir:
+            tfile = os.path.join(tdir, 'testfile')
+            with compress(tfile + ".gz") as compressed_file:
                 self.create_file(compressed_file)
 
-            with decompress(file.name+".gz") as uncompressed_file:
+            with decompress(tfile + ".gz") as uncompressed_file:
                 assert self.check_file(uncompressed_file)
 
     def test_compress_decompress_bz2(self):
-        with NamedTemporaryFile() as file:
-            with compress(file.name+".bz2") as compressed_file:
+        with TemporaryDirectory() as tdir:
+            tfile = os.path.join(tdir, 'testfile')
+            with compress(tfile + ".bz2") as compressed_file:
                 self.create_file(compressed_file)
 
-            with decompress(file.name+".bz2") as uncompressed_file:
+            with decompress(tfile + ".bz2") as uncompressed_file:
                 assert self.check_file(uncompressed_file)
 
     def test_compress_decompress_lzma(self):
-        with NamedTemporaryFile() as file:
-            with compress(file.name+".xz") as compressed_file:
+        with TemporaryDirectory() as tdir:
+            tfile = os.path.join(tdir, 'testfile')
+            with compress(tfile + ".xz") as compressed_file:
                 self.create_file(compressed_file)
 
-            with decompress(file.name+".xz") as uncompressed_file:
+            with decompress(tfile + ".xz") as uncompressed_file:
                 assert self.check_file(uncompressed_file)


### PR DESCRIPTION
Temporary files were left behind in many (test) cases.

A number of tests failed on Windows due to files being opened twice for writing.