### PR TITLE
Fix failing filecomparison.

### DIFF
--- a/typhon/tests/plots/test_colors.py
+++ b/typhon/tests/plots/test_colors.py
@@ -37,14 +37,16 @@ class TestColors:
         colors.cmap2cpt('viridis', filename=self.f)
         ref = os.path.join(self.ref_dir, 'viridis.cpt')
 
-        assert filecmp.cmp(self.f, ref)
+        with open(self.f) as testfile, open(ref) as reffile:
+            assert testfile.readlines() == reffile.readlines()
 
     def test_cmap2txt(self):
         """Export colormap to txt file."""
         colors.cmap2txt('viridis', filename=self.f)
         ref = os.path.join(self.ref_dir, 'viridis.txt')
 
-        assert filecmp.cmp(self.f, ref)
+        with open(self.f) as testfile, open(ref) as reffile:
+            assert testfile.readlines() == reffile.readlines()
 
     def test_cmap2act(self):
         """Export colormap to act file."""

--- a/typhon/tests/utils/test_latex.py
+++ b/typhon/tests/utils/test_latex.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Testing the functions in typhon.latex.
 """
-import filecmp
 import os
 from tempfile import mkstemp
 
@@ -35,4 +34,6 @@ class TestLaTeX:
             delimiter=False
             )
 
-        assert filecmp.cmp(self.f, os.path.join(self.ref_dir, 'matrix.tex'))
+        ref = os.path.join(self.ref_dir, 'matrix.tex')
+        with open(self.f) as testfile, open(ref) as reffile:
+            assert testfile.readlines() == reffile.readlines()


### PR DESCRIPTION
Use manual filecomparison. filecmp failed in certain windows
configurations (e.g. AppVeyor).