### PR TITLE
Implement GriddedField.from_xarray()

### DIFF
--- a/typhon/arts/griddedfield.py
+++ b/typhon/arts/griddedfield.py
@@ -82,7 +82,8 @@ class GriddedField(object):
 
     def __eq__(self, other):
         """Test the equality of GriddedFields."""
-        if isinstance(other, self.__class__):
+        if (isinstance(other, self.__class__) or
+                isinstance(self, other.__class__)):
             # Check each attribute after another for readabilty.
             # Return as soon as possible for performance.
             if self.name != other.name:

--- a/typhon/arts/griddedfield.py
+++ b/typhon/arts/griddedfield.py
@@ -513,6 +513,7 @@ class GriddedField(object):
                 if len(coor)>0})
         if self.name is not None:
             da.name = self.name
+        da.attrs['data_name'] = self.dataname
         return da
 
     @classmethod

--- a/typhon/arts/griddedfield.py
+++ b/typhon/arts/griddedfield.py
@@ -582,6 +582,31 @@ class GriddedField(object):
         obj.check_dimension()
         return obj
 
+    @classmethod
+    def from_xarray(cls, da):
+        """Create GriddedField from a xarray.DataArray object.
+
+        The data and its dimensions are returned as a :class:`GriddedField` object.
+        The DataArray name is used as name for the gridded field. If the attribute
+        `data_name` is present, it is used as `dataname` on the :class:`GriddedField`.
+
+        Parameters:
+            da (xarray.DataArray): xarray.DataArray containing the dimensions and data.
+
+        Returns:
+            GriddedField object.
+
+        """
+        obj = cls(da.ndim)
+        obj.grids = [da[c].values for c in da.dims]
+        obj.gridnames = list(da.dims)
+        obj.data = da.values
+        obj.dataname = da.attrs.get('data_name', 'Data')
+        if da.name:
+            obj.name = da.name
+        obj.check_dimension()
+        return obj
+
     def to_atmlab_dict(self):
         """Returns a copy of the GriddedField as a dictionary.
 

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -285,6 +285,13 @@ class TestGriddedFieldLoad:
         # Grids should not be the same object.
         assert a.grids is not b.grids
 
+    def test_from_xarray(self):
+        a = xml.load(self.ref_dir + 'GriddedField3.xml')
+        a.dataname = 'Testdata'
+        da = a.to_xarray()
+        b = griddedfield.GriddedField.from_xarray(da)
+        assert a == b
+
 
 class TestGriddedFieldWrite:
     def setup_method(self):


### PR DESCRIPTION
This PR would implement the `GriddedField.from_xarray()` method. In order for this to work, I had to touch the existing code (see commits):

1. Because `GriddedField.from_xarray()` (as does `from_nc()`) returns a `GriddedField` instead of `GriddedField[1234...]`, I had to adjust the `__eq__` operator to make comparisons work.
2. Because `GriddedField.name` corresponds to `DataArray.name`, I added a `data_name` attribute in `to_xarray()` to keep the `dataname`.

Regarding 1, there might be better solutions (for example not using the base class `GriddedField` at all) but I didn't want to mess with the code too much.

I'm happy to rework the commits if required.