### PR TITLE
Make pytest run against the installed typhon.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - |
     case ${CONFIG} in
       TEST)
-        pytest
+        pytest --pyargs typhon
         ;;
       PEP8)
         pip install flake8


### PR DESCRIPTION
pytest was wrongly called on the source tree. We want to actually test
the installed version. This helps to detect issues with missing files
in MANIFEST.in.