### PR TITLE
Clean `GriddedField` public API.

### DIFF
--- a/doc/typhon.arts.rst
+++ b/doc/typhon.arts.rst
@@ -40,13 +40,15 @@ arts.griddedfield
 .. autosummary::
    :toctree: generated
 
-   GriddedField
    GriddedField1
    GriddedField2
    GriddedField3
    GriddedField4
    GriddedField5
    GriddedField6
+   GriddedField7
+   griddedfield_from_netcdf
+   griddedfield_from_xarray
 
 arts.internals
 ===============

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -30,7 +30,7 @@ class TestGriddedFieldUsage:
     def test_check_init(self):
         """Test initialisation of GriddedFields."""
         for dim in np.arange(1, 8):
-            gf = griddedfield.GriddedField(dim)
+            gf = griddedfield._GriddedField(dim)
             assert gf.dimension == dim
 
     def test_check_dimension1(self):
@@ -289,7 +289,7 @@ class TestGriddedFieldLoad:
         a = xml.load(self.ref_dir + 'GriddedField3.xml')
         a.dataname = 'Testdata'
         da = a.to_xarray()
-        b = griddedfield.GriddedField.from_xarray(da)
+        b = griddedfield.GriddedField3.from_xarray(da)
         assert a == b
 
 
@@ -305,7 +305,7 @@ class TestGriddedFieldWrite:
 
     @pytest.mark.parametrize("dim", range(1, 8))
     def test_write_load_griddedfield(self, dim):
-        gf = griddedfield.GriddedField(dim)
+        gf = griddedfield._GriddedField(dim)
         gf.grids = [np.arange(2)] * dim
         gf.data = _create_tensor(dim)
         xml.save(gf, self.f)

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -24,14 +24,27 @@ def _create_tensor(n):
     return np.arange(2 ** n).reshape(2 * np.ones(n).astype(int))
 
 
+def _get_griddedfield_type(dim):
+    """Return the appropriate `GriddedField` type for given dimension."""
+    return {
+        1: griddedfield.GriddedField1,
+        2: griddedfield.GriddedField2,
+        3: griddedfield.GriddedField3,
+        4: griddedfield.GriddedField4,
+        5: griddedfield.GriddedField5,
+        6: griddedfield.GriddedField6,
+        7: griddedfield.GriddedField7,
+    }.get(dim)
+
+
 class TestGriddedFieldUsage:
     ref_dir = os.path.join(os.path.dirname(__file__), "reference", "")
 
-    def test_check_init(self):
+    @pytest.mark.parametrize("dim", range(1, 8))
+    def test_check_init(self, dim):
         """Test initialisation of GriddedFields."""
-        for dim in np.arange(1, 8):
-            gf = griddedfield._GriddedField(dim)
-            assert gf.dimension == dim
+        cls = _get_griddedfield_type(dim)
+        assert cls().dimension == dim
 
     def test_check_dimension1(self):
         """Test if grid and data dimension agree (positive)."""
@@ -305,7 +318,7 @@ class TestGriddedFieldWrite:
 
     @pytest.mark.parametrize("dim", range(1, 8))
     def test_write_load_griddedfield(self, dim):
-        gf = griddedfield._GriddedField(dim)
+        gf = _get_griddedfield_type(dim)()
         gf.grids = [np.arange(2)] * dim
         gf.data = _create_tensor(dim)
         xml.save(gf, self.f)


### PR DESCRIPTION
This PR has been motivated by #221 and consists of:
* Remove the `GriddedField` base class from the public API as it should
not be used directly. Add convencience functions to create objects of
the appropriate `GriddedField` type from `xarray.Dataset` and netCDF.
* Add missing `GriddedField7` class.

Cheers,
Lukas