### PR TITLE
Clean `GriddedField` API

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -328,7 +328,8 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'skimage': ('http://scikit-image.org/docs/stable', None),
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
-    'matplotlib': ('https://matplotlib.org', None)
+    'matplotlib': ('https://matplotlib.org', None),
+    'xarray': ('http://xarray.pydata.org/en/stable/', None),
 }
 
 # -- Plots ----------------------------------------------------------------

--- a/doc/typhon.arts.rst
+++ b/doc/typhon.arts.rst
@@ -40,13 +40,14 @@ arts.griddedfield
 .. autosummary::
    :toctree: generated
 
-   GriddedField
    GriddedField1
    GriddedField2
    GriddedField3
    GriddedField4
    GriddedField5
    GriddedField6
+   griddedfield_from_netcdf
+   griddedfield_from_xarray
 
 arts.internals
 ===============

--- a/typhon/arts/griddedfield.py
+++ b/typhon/arts/griddedfield.py
@@ -716,9 +716,10 @@ def griddedfield_from_netcdf(ncfile, **kwargs):
     Parameters:
         ncfile (str): Path to netCDF file.
         **kwargs: Additional keyword arguments are passed
-            to `_GriddedField.from_nc`.
+            to the :func:`~GriddedField1.from_nc` method.
 
-    Returns: Appropriate ARTS GriddedField.
+    Returns:
+        : Appropriate ARTS GriddedField.
     """
     with netCDF4.Dataset(ncfile) as root:
         cls = _griddedfield_from_ndim(root.ndim)
@@ -727,11 +728,13 @@ def griddedfield_from_netcdf(ncfile, **kwargs):
 
 
 def griddedfield_from_xarray(dataarray):
-    """Convert ``xr.DataArray`` to ARTS ``GriddedField``.
+    """Convert :class:`xarray.DataArray` to ARTS ``GriddedField``.
 
     Parameters:
-        da (``xr.DataArray``): ``xr.DataArray`` containing dimensions and data.
+        da (:class:`xarray.DataArray`): :class:`~xarray.DataArray` containing
+            dimensions and data.
 
-    Returns: Appropriate ARTS GriddedField.
+    Returns:
+        : Appropriate ARTS GriddedField.
     """
     return _griddedfield_from_ndim(dataarray.ndim).from_xarray(dataarray)

--- a/typhon/arts/griddedfield.py
+++ b/typhon/arts/griddedfield.py
@@ -2,24 +2,26 @@
 import copy
 import numbers
 
+import netCDF4
 import numpy as np
 import xarray
 from scipy import interpolate
 
 from .utils import return_if_arts_type, get_arts_typename
 
-__all__ = ['GriddedField',
-           'GriddedField1',
-           'GriddedField2',
-           'GriddedField3',
-           'GriddedField4',
-           'GriddedField5',
-           'GriddedField6',
-           'GriddedField7',
-           ]
+__all__ = [
+    'GriddedField1',
+    'GriddedField2',
+    'GriddedField3',
+    'GriddedField4',
+    'GriddedField5',
+    'GriddedField6',
+    'griddedfield_from_netcdf',
+    'griddedfield_from_xarray',
+]
 
 
-class GriddedField(object):
+class _GriddedField:
     """:class:`GriddedField` implements the same-named ARTS dataype.
 
     This class provides the facility of storing gridded data. For this purpose
@@ -349,7 +351,7 @@ class GriddedField(object):
             axis (int): Axis to slice along.
 
         Returns:
-            :class:`typhon.arts.griddedfield.GriddedField`:
+            :class:`typhon.arts.griddedfield._GriddedField`:
                 GriddedField containing sliced grids and data.
         """
         gf = self.copy()
@@ -536,22 +538,20 @@ class GriddedField(object):
             Exception: If the variable key can't be found in the netCDF file.
 
         """
-        from netCDF4 import Dataset
-        nc = Dataset(inputfile)
+        with netCDF4.Dataset(inputfile) as nc:
+            if variable not in nc.variables:
+                raise Exception('netCDF file has no variable {}.'.format(variable))
 
-        if variable not in nc.variables:
-            raise Exception('netCDF file has no variable {}.'.format(variable))
+            data = nc.variables[variable]
 
-        data = nc.variables[variable]
+            obj = cls()
+            obj.grids = [nc.variables[dim][:] for dim in data.dimensions]
+            obj.gridnames = [dim for dim in data.dimensions]
 
-        obj = cls(data.ndim)
-        obj.grids = [nc.variables[dim][:] for dim in data.dimensions]
-        obj.gridnames = [dim for dim in data.dimensions]
-
-        if isinstance(data[:], np.ma.MaskedArray):
-            obj.data = data[:].filled(fill_value=fill_value)
-        else:
-            obj.data = data[:]
+            if isinstance(data[:], np.ma.MaskedArray):
+                obj.data = data[:].filled(fill_value=fill_value)
+            else:
+                obj.data = data[:]
 
         obj.check_dimension()
 
@@ -599,7 +599,7 @@ class GriddedField(object):
             GriddedField object.
 
         """
-        obj = cls(da.ndim)
+        obj = cls()
         obj.grids = [da[c].values for c in da.dims]
         obj.gridnames = list(da.dims)
         obj.data = da.values
@@ -655,50 +655,83 @@ class GriddedField(object):
         xmlwriter.close_tag()
 
 
-class GriddedField1(GriddedField):
-    """GriddedField with 1 dimension."""
+class GriddedField1(_GriddedField):
+    """Implements a :arts:`GriddedField1`."""
 
     def __init__(self, *args, **kwargs):
         super(GriddedField1, self).__init__(1, *args, **kwargs)
 
 
-class GriddedField2(GriddedField):
-    """GriddedField with 2 dimensions."""
+class GriddedField2(_GriddedField):
+    """Implements a :arts:`GriddedField2`."""
 
     def __init__(self, *args, **kwargs):
         super(GriddedField2, self).__init__(2, *args, **kwargs)
 
 
-class GriddedField3(GriddedField):
-    """GriddedField with 3 dimensions."""
+class GriddedField3(_GriddedField):
+    """Implements a :arts:`GriddedField3`."""
 
     def __init__(self, *args, **kwargs):
         super(GriddedField3, self).__init__(3, *args, **kwargs)
 
 
-class GriddedField4(GriddedField):
-    """GriddedField with 4 dimensions."""
+class GriddedField4(_GriddedField):
+    """Implements a :arts:`GriddedField4`."""
 
     def __init__(self, *args, **kwargs):
         super(GriddedField4, self).__init__(4, *args, **kwargs)
 
 
-class GriddedField5(GriddedField):
-    """GriddedField with 5 dimensions."""
+class GriddedField5(_GriddedField):
+    """Implements a :arts:`GriddedField5`."""
 
     def __init__(self, *args, **kwargs):
         super(GriddedField5, self).__init__(5, *args, **kwargs)
 
 
-class GriddedField6(GriddedField):
-    """GriddedField with 6 dimensions."""
+class GriddedField6(_GriddedField):
+    """Implements a :arts:`GriddedField6`."""
 
     def __init__(self, *args, **kwargs):
         super(GriddedField6, self).__init__(6, *args, **kwargs)
 
 
-class GriddedField7(GriddedField):
-    """GriddedField with 7 dimensions."""
+def _griddedfield_from_ndim(ndim):
+    """Determine proper GriddedField type from number of dimensions."""
+    griddefield_dimension_map = {
+        1: GriddedField1,
+        2: GriddedField2,
+        3: GriddedField3,
+        4: GriddedField4,
+        5: GriddedField5,
+        6: GriddedField6,
+    }
+    return griddefield_dimension_map[ndim]
 
-    def __init__(self, *args, **kwargs):
-        super(GriddedField7, self).__init__(7, *args, **kwargs)
+
+def griddedfield_from_netcdf(ncfile, **kwargs):
+    """Create an ARTS ``GriddedField`` of appropriate dimension from netCDF.
+
+    Parameters:
+        ncfile (str): Path to netCDF file.
+        **kwargs: Additional keyword arguments are passed
+            to `_GriddedField.from_nc`.
+
+    Returns: Appropriate ARTS GriddedField.
+    """
+    with netCDF4.Dataset(ncfile) as root:
+        cls = _griddedfield_from_ndim(root.ndim)
+
+    return cls.from_nc(ncfile, **kwargs)
+
+
+def griddedfield_from_xarray(dataarray):
+    """Convert ``xr.DataArray`` to ARTS ``GriddedField``.
+
+    Parameters:
+        da (``xr.DataArray``): ``xr.DataArray`` containing dimensions and data.
+
+    Returns: Appropriate ARTS GriddedField.
+    """
+    return _griddedfield_from_ndim(dataarray.ndim).from_xarray(dataarray)

--- a/typhon/arts/types.py
+++ b/typhon/arts/types.py
@@ -8,7 +8,6 @@ from .griddedfield import (GriddedField1,
                            GriddedField4,
                            GriddedField5,
                            GriddedField6,
-                           GriddedField7,
                            )
 from .covariancematrix import (CovarianceMatrix)
 from .scattering import (SingleScatteringData,
@@ -49,7 +48,6 @@ classes = {
     'GriddedField4': GriddedField4,
     'GriddedField5': GriddedField5,
     'GriddedField6': GriddedField6,
-    'GriddedField7': GriddedField7,
     'LineMixingRecord': LineMixingRecord,
     'QuantumIdentifier': QuantumIdentifier,
     'QuantumNumberRecord': QuantumNumberRecord,

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -24,14 +24,26 @@ def _create_tensor(n):
     return np.arange(2 ** n).reshape(2 * np.ones(n).astype(int))
 
 
+def _get_griddedfield_type(dim):
+    """Return the appropriate `GriddedField` type for given dimension."""
+    return {
+        1: griddedfield.GriddedField1,
+        2: griddedfield.GriddedField2,
+        3: griddedfield.GriddedField3,
+        4: griddedfield.GriddedField4,
+        5: griddedfield.GriddedField5,
+        6: griddedfield.GriddedField6,
+    }.get(dim)
+
+
 class TestGriddedFieldUsage:
     ref_dir = os.path.join(os.path.dirname(__file__), "reference", "")
 
-    def test_check_init(self):
+    @pytest.mark.parametrize("dim", range(1, 7))
+    def test_check_init(self, dim):
         """Test initialisation of GriddedFields."""
-        for dim in np.arange(1, 8):
-            gf = griddedfield._GriddedField(dim)
-            assert gf.dimension == dim
+        cls = _get_griddedfield_type(dim)
+        assert cls().dimension == dim
 
     def test_check_dimension1(self):
         """Test if grid and data dimension agree (positive)."""
@@ -303,9 +315,9 @@ class TestGriddedFieldWrite:
         """Delete temporary file."""
         os.remove(self.f)
 
-    @pytest.mark.parametrize("dim", range(1, 8))
+    @pytest.mark.parametrize("dim", range(1, 7))
     def test_write_load_griddedfield(self, dim):
-        gf = griddedfield._GriddedField(dim)
+        gf = _get_griddedfield_type(dim)()
         gf.grids = [np.arange(2)] * dim
         gf.data = _create_tensor(dim)
         xml.save(gf, self.f)

--- a/typhon/tests/arts/test_griddedfield.py
+++ b/typhon/tests/arts/test_griddedfield.py
@@ -30,7 +30,7 @@ class TestGriddedFieldUsage:
     def test_check_init(self):
         """Test initialisation of GriddedFields."""
         for dim in np.arange(1, 8):
-            gf = griddedfield.GriddedField(dim)
+            gf = griddedfield._GriddedField(dim)
             assert gf.dimension == dim
 
     def test_check_dimension1(self):
@@ -289,7 +289,7 @@ class TestGriddedFieldLoad:
         a = xml.load(self.ref_dir + 'GriddedField3.xml')
         a.dataname = 'Testdata'
         da = a.to_xarray()
-        b = griddedfield.GriddedField.from_xarray(da)
+        b = griddedfield.GriddedField3.from_xarray(da)
         assert a == b
 
 
@@ -305,7 +305,7 @@ class TestGriddedFieldWrite:
 
     @pytest.mark.parametrize("dim", range(1, 8))
     def test_write_load_griddedfield(self, dim):
-        gf = griddedfield.GriddedField(dim)
+        gf = griddedfield._GriddedField(dim)
         gf.grids = [np.arange(2)] * dim
         gf.data = _create_tensor(dim)
         xml.save(gf, self.f)


### PR DESCRIPTION
This PR has been motivated by #221 and consists of:
* Remove the `GriddedField` base class from the public API as it should
not be used directly. Add convencience functions to create objects of
the appropriate `GriddedField` type from `xarray.Dataset` and netCDF.

Cheers,
Lukas