### PR TITLE
Add function to convert pressure into height.

### DIFF
--- a/doc/typhon.physics.rst
+++ b/doc/typhon.physics.rst
@@ -22,6 +22,7 @@ physics
    planck
    planck_wavelength
    planck_wavenumber
+   pressure2height
    radiance2planckTb
    radiance2rayleighjeansTb
    rayleighjeans

--- a/typhon/tests/physics/test_atmosphere.py
+++ b/typhon/tests/physics/test_atmosphere.py
@@ -74,3 +74,22 @@ class TestAtmosphere:
         isa = atmosphere.standard_atmosphere
 
         assert np.isclose(isa(1000e2, coordinates='pressure'), 288.0527)
+
+    def test_pressure2height(self):
+        """Test conversion from atmospheric pressure to height."""
+        p = np.array([1000e2, 750e2, 500e2, 100e2])
+
+        z = atmosphere.pressure2height(p)
+        z_ref = np.array([2107.945, 4783.644, 10749.031, 36115.850])
+
+        assert np.allclose(z, z_ref)
+
+    def test_pressure2height_with_T(self):
+        """Test conversion from atmospheric pressure to height."""
+        p = np.array([1000e2, 750e2, 500e2, 100e2])
+        T = np.array([288, 275, 255, 215])
+
+        z = atmosphere.pressure2height(p, T=T)
+        z_ref = np.array([2107.559, 4790.794, 10762.213, 35935.839])
+
+        assert np.allclose(z, z_ref)


### PR DESCRIPTION
This PR implements a function to convert an array with atmospheric pressures into height. An optional temperature profile may be passed to calculate the air density, if not the standard atmosphere is assumed.