### PR TITLE
Fix conversion from pressure to height.

### DIFF
--- a/typhon/physics/atmosphere.py
+++ b/typhon/physics/atmosphere.py
@@ -252,18 +252,21 @@ def pressure2height(p, T=None):
             If ``None`` the standard atmosphere is assumed.
 
     See also:
-        :func:`~typhon.physics.standard_atmosphere`:
-            Standard atmospheric temperature profile as function of pressure.
+        .. autosummary::
+            :nosignatures:
+
+            standard_atmosphere
 
     Returns:
-        ndarray: Height [m].
+        ndarray: Relative height above lowest pressure level [m].
     """
     if T is None:
         T = standard_atmosphere(p, coordinates='pressure')
 
-    dp = np.diff(p)
-    dp = np.hstack([dp, dp[-1]])
+    layer_depth = np.diff(p)
     rho = thermodynamics.density(p, T)
-    g = constants.earth_standard_gravity
+    rho_layer = 0.5 * (rho[:-1] + rho[1:])
 
-    return np.cumsum(-dp / (rho * g))
+    z = np.cumsum(-layer_depth / (rho_layer * constants.g))
+
+    return np.hstack([0, z])

--- a/typhon/tests/physics/test_atmosphere.py
+++ b/typhon/tests/physics/test_atmosphere.py
@@ -96,7 +96,7 @@ class TestAtmosphere:
         p = np.array([1000e2, 750e2, 500e2, 100e2])
 
         z = atmosphere.pressure2height(p)
-        z_ref = np.array([2107.945, 4783.644, 10749.031, 36115.850])
+        z_ref = np.array([0., 2358.129, 5473.647, 15132.902])
 
         assert np.allclose(z, z_ref)
 
@@ -106,6 +106,6 @@ class TestAtmosphere:
         T = np.array([288, 275, 255, 215])
 
         z = atmosphere.pressure2height(p, T=T)
-        z_ref = np.array([2107.559, 4790.794, 10762.213, 35935.839])
+        z_ref = np.array([0., 2360.809, 5482.749, 15135.793])
 
         assert np.allclose(z, z_ref)


### PR DESCRIPTION
Fix mismatch between dp and rho(p, T) that lead to differences
especially in high altitudes. In addition, the new implementation
defines the height of the lowest pressure level to be 0 m.