### PR TITLE
RTTOV uses 1 not 2 digits for noaa-6–9

### DIFF
--- a/typhon/datasets/tovs.py
+++ b/typhon/datasets/tovs.py
@@ -2168,7 +2168,7 @@ def norm_tovs_name(satname, mode="default"):
                     elif k == "metopb":
                         return "metop_1"
                     elif k.startswith("noaa"):
-                        return "noaa_{:>02d}".format(int(k[-2:], 10))
+                        return "noaa_{:>d}".format(int(k[-2:], 10))
                     else:
                         raise RuntimeError(f"Should not happen: reference name {k:s}")
                 elif mode == "BC":


### PR DESCRIPTION
Fix names for reading SRFS for noaa-6–9