### PR TITLE
Improve precision for storing time from 1s to 100ms

### DIFF
--- a/typhon/datasets/_tovs_defs.py
+++ b/typhon/datasets/_tovs_defs.py
@@ -490,6 +490,7 @@ _cal_coding = _coding.copy()
 _cal_coding.update({
     "calendar": "proleptic_gregorian",
     "_FillValue": -2147483647,
+    "scale_factor": 0.1, # default precision 100 ms
     "dtype": "i4"})
 
 # ('hrs_scnlin',


### PR DESCRIPTION
When converting a dataset to L1C in xarray form in order to write to
NetCDF, store time with a scale factor of 0.1 so that the precision will
be at best 100 ms rather than 1 s, the latter which loses precision for
TOVS scanlines.