### PR TITLE
Switch appveyor build back to pip.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,8 +10,6 @@ init:
 
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
   - pip install pytest
   - pip install .
   - git clone --depth=1 https://github.com/atmtools/typhon-testfiles.git

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,9 +11,7 @@ init:
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge
   - conda update -q conda
-  - conda install --file requirements.txt
   - pip install pytest
   - pip install .
   - git clone --depth=1 https://github.com/atmtools/typhon-testfiles.git


### PR DESCRIPTION
Since miniconda in the appveyor VM runs terribly slow, we're changing back to pip and skipping miniconda updates to speed up the build.