### PR TITLE
Don't fail if queue.qsize is not available.

### DIFF
--- a/typhon/collocations/collocator.py
+++ b/typhon/collocations/collocator.py
@@ -289,10 +289,13 @@ class Collocator:
                 else:
                     process_progress[process] = progress
 
+                try:
+                    nerrors = errors.qsize()
+                except NotImplementedError:
+                    nerrors = 'unknown'
+
                 self._print_progress(
-                    timer.elapsed, process_progress, len(running),
-                    errors.qsize()
-                )
+                    timer.elapsed, process_progress, len(running), nerrors)
                 if result is not None:
                     yield result
 

--- a/typhon/tests/collocations/test_collocations.py
+++ b/typhon/tests/collocations/test_collocations.py
@@ -15,7 +15,6 @@ class TestCollocations:
 
     refdir = get_testfiles_directory("collocations")
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="Test does not work on OSX.")
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
     def test_search(self):
         """Collocate fake MHS filesets"""


### PR DESCRIPTION
On some systems qsize() fails with an unimplemented error. Since this is
only used for progress status output, the exception can be safely ignored.
Instead of the number of failed processes, 'unknown' is shown in the
output instead.