### PR TITLE
Fix cython error

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ init:
 
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - C:\\Miniconda36-x64\\python.exe -m pip install -U pip
   - pip install Cython
   - pip install pytest
   - pip install .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,7 @@ install:
   - C:\\Miniconda36-x64\\python.exe -m pip install -U pip
   - pip install Cython
   - pip install pytest
+  - pip install git+https://github.com/Unidata/cftime
   - pip install .
   - git clone --depth=1 https://github.com/atmtools/typhon-testfiles.git
   - "set TYPHONTESTFILES=%cd%\\typhon-testfiles"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ init:
 
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - pip install Cython
   - pip install pytest
   - pip install .
   - git clone --depth=1 https://github.com/atmtools/typhon-testfiles.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   allow_failures:
     - env: CONFIG=PEP8
 install:
+  - pip install Cython
   - pip install .[tests]
   - git clone --depth=1 https://github.com/atmtools/typhon-testfiles.git
   - export TYPHONTESTFILES=$PWD/typhon-testfiles

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   allow_failures:
     - env: CONFIG=PEP8
 install:
+  - pip install -U pip
   - pip install Cython
   - pip install .[tests]
   - git clone --depth=1 https://github.com/atmtools/typhon-testfiles.git


### PR DESCRIPTION
The cftime package by Unidata is currently broken in multiple ways. It is using Cython in its setup.py which breaks pip's dependency tracking. We need to install Cython manually to resolve this. Also, the current version from PyPi fails to install on Windows. As a workaround we pull it from github directly for the AppVeyor build.