### PR TITLE
Add missing definitions to RST files

### DIFF
--- a/doc/typhon.datasets.rst
+++ b/doc/typhon.datasets.rst
@@ -33,6 +33,30 @@ datasets.dataset
    SingleFileDataset
    SingleMeasurementPerFileDataset
 
+datasets.filters
+================
+
+.. automodule:: typhon.datasets.filters
+
+.. currentmodule:: typhon.datasets.filters
+
+.. autosummary::
+   :toctree: generated
+
+   FilterError
+   OutlierFilter
+   MEDMAD
+   OrbitFilter
+   TimeMaskFilter
+   HIRSTimeSequenceDuplicateFilter
+   HIRSFlagger
+   HIRSCalibCountFilter
+   HIRSPRTTempFilter
+   OverlapFilter
+   FirstlineDBFilter
+   NullLineFilter
+   HIRSBestLineFilter
+
 datasets.model
 ==============
 

--- a/doc/typhon.physics.rst
+++ b/doc/typhon.physics.rst
@@ -55,4 +55,4 @@ physics.metrology
    :toctree: generated
 
    express_uncertainty
-
+   recursive_args

--- a/doc/typhon.physics.units.rst
+++ b/doc/typhon.physics.units.rst
@@ -27,3 +27,14 @@ physics.units.constants
 .. autosummary::
    :toctree: generated
 
+physics.units.tools
+===================
+
+.. automodule:: typhon.physics.units.tools
+
+.. currentmodule:: typhon.physics.units.tools
+
+.. autosummary::
+   :toctree: generated
+
+   UnitsAwareDataArray


### PR DESCRIPTION
Some functions and classes were not documented.  Add those to the RST files manually.

@olemke I'm a bit new to sphinx and ReST.  I think some of my docstrings are causing warnings, which I should fix, but can you check if I've at least added the directives to the rst files correctly and consistently in this PR?

Will http://www.radiativetransfer.org/misc/typhon/doc-trunk/ get updated automatically?