### PR TITLE
Revise style handling and add dark theme

### DIFF
--- a/doc/pyplots/stylesheet_gallery.py
+++ b/doc/pyplots/stylesheet_gallery.py
@@ -3,7 +3,7 @@
 """
 import numpy as np
 import matplotlib.pyplot as plt
-import typhon
+from typhon.plots import styles
 
 
 def simple_plot(stylename):
@@ -27,9 +27,8 @@ def simple_plot(stylename):
 simple_plot('matplotlib 2.0')
 
 # Create a plot for each available typhon style.
-for style_name in typhon.plots.get_available_styles():
-    style_path = typhon.plots.styles(style_name)
-    with plt.style.context(style_path):
+for style_name in styles.available:
+    with plt.style.context(styles(style_name)):
         simple_plot(style_name)
 
 plt.show()

--- a/doc/pyplots/stylesheet_gallery.py
+++ b/doc/pyplots/stylesheet_gallery.py
@@ -8,6 +8,10 @@ from typhon.plots import styles
 
 def simple_plot(stylename):
     """Generate a simple plot using a given matplotlib style."""
+    if stylename == 'typhon-dark':
+        # TODO: Sphinx build is broken for non-white figure facecolor.
+        return
+
     x = np.linspace(0, np.pi, 20)
 
     fig, ax = plt.subplots()

--- a/typhon/plots/common.py
+++ b/typhon/plots/common.py
@@ -11,6 +11,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from typhon import constants
 
+from typhon.utils import deprecated
+
+
 __all__ = [
     'center_colorbar',
     'figsize',
@@ -165,10 +168,18 @@ class _StyleHandler:
         """
         plt.style.use(self.get(name))
 
+    @property
+    def available(self):
+        """Return list of available typhon styles."""
+        pattern = os.path.join(self.stylelib_dir, '*.mplstyle')
+
+        return [os.path.splitext(os.path.basename(s))[0]
+                for s in glob.glob(pattern)]
 
 styles = _StyleHandler()
 
 
+@deprecated(new_name='typhon.plots.styles.available')
 def get_available_styles():
     """Return list of names of all styles shipped with typhon.
 

--- a/typhon/plots/common.py
+++ b/typhon/plots/common.py
@@ -145,7 +145,15 @@ class _StyleHandler:
         if name is None:
             name = 'typhon'
 
-        return os.path.join(self.stylelib_dir, name + '.mplstyle')
+        style_path = os.path.join(self.stylelib_dir, name + '.mplstyle')
+
+        if os.path.isfile(style_path):
+            return style_path
+        else:
+            raise ValueError(
+                f'"{name}" is not a valid style. '
+                f'See ``styles.available`` for list of available styles.'
+        )
 
     def get(self, name=None):
         """Return absolute path to typhon stylesheet.

--- a/typhon/plots/common.py
+++ b/typhon/plots/common.py
@@ -116,6 +116,10 @@ class _StyleHandler:
 
         >>> styles.use('typhon')
 
+        You can also get/use several styles at a time:
+
+        >>> styles.use(['typhon', 'typhon-dark'])
+
     Parameters:
         name (str): Style name.
 
@@ -126,18 +130,39 @@ class _StyleHandler:
         self.stylelib_dir = os.path.join(os.path.dirname(__file__), 'stylelib')
 
     def __call__(self, name=None):
-        """Return absolute path to typhon stylesheet."""
+        """Return absolute path to typhon stylesheet.
+
+        Parameters:
+            name (str, list): Style name or list of style names.
+        """
         return self.get(name)
 
-    def get(self, name=None):
-        """Return absolute path to typhon stylesheet."""
+    def _get_style(self, name=None):
+        """Return absolute path to a single typhon stylesheet."""
         if name is None:
             name = 'typhon'
 
         return os.path.join(self.stylelib_dir, name + '.mplstyle')
 
+    def get(self, name=None):
+        """Return absolute path to typhon stylesheet.
+
+        Parameters:
+            name (str, list): Style name or list of style names.
+        """
+        if isinstance(name, list):
+            return [self._get_style(n) for n in name]
+        elif isinstance(name, str):
+            return self._get_style(name)
+        else:
+            raise TypeError('``name`` has to be of type str or list.')
+
     def use(self, name=None):
-        """Use matplotlib style settings from a typhon style specification."""
+        """Use matplotlib style settings from a typhon style specification.
+
+        Parameters:
+            name (str, list): Style name or list of style names.
+        """
         plt.style.use(self.get(name))
 
 

--- a/typhon/plots/stylelib/typhon-dark.mplstyle
+++ b/typhon/plots/stylelib/typhon-dark.mplstyle
@@ -1,0 +1,22 @@
+# Set black background default line colors to white.
+
+lines.color: white
+patch.edgecolor: white
+
+text.color: white
+
+axes.facecolor: 333333
+axes.edgecolor: white
+axes.labelcolor: white
+axes.prop_cycle: cycler('color', ['ff8a80', '82b1ff', 'b9f6ca', 'ea80fc', 'ffd180', 'ff80ab', '84ffff', 'f4ff81'])
+
+xtick.color: white
+ytick.color: white
+
+grid.color: grey
+
+figure.facecolor: 333333
+figure.edgecolor: 333333
+
+savefig.facecolor: 333333
+savefig.edgecolor: 333333

--- a/typhon/tests/plots/test_plots.py
+++ b/typhon/tests/plots/test_plots.py
@@ -3,6 +3,8 @@
 """
 import os
 
+import pytest
+
 from typhon import plots
 
 
@@ -19,13 +21,19 @@ class TestPlots:
         shape = plots.get_subplot_arrangement(8)
         assert shape == (3, 3)
 
-    def test_get_available_styles(self):
-        """Check matplotlib stylesheet paths.
+    def test_get_style_path_method(self):
+        assert os.path.isfile(plots.styles.get('typhon'))
 
-        This test checks the consinstency of the in and outputs
-        of styles() and get_available_styles().
-        """
-        style_paths = [
-            plots.styles(s) for s in plots.get_available_styles()]
+    def test_get_style_path_call(self):
+        assert os.path.isfile(plots.styles('typhon'))
 
-        assert all(os.path.isfile(s) for s in style_paths)
+    def test_undefined_style(self):
+        with pytest.raises(ValueError):
+            plots.styles.get('Undefined Stylesheet Name')
+
+    def test_available_styles(self):
+        style_paths = plots.styles.available
+
+        assert isinstance(style_paths, list)
+        assert len(style_paths) > 0
+        assert all(os.path.isfile(plots.styles(s)) for s in style_paths)


### PR DESCRIPTION
This PR:
* ``typhon.plots.styles`` raises a ``ValueError`` for unavailable styles.
* It is possible to pass a list of style names to ``typhon.plots.styles`` and its methods.
* ``typhon.plots.get_available_styles()`` is deprecated, use ``typhon.plots.styles.available`` instead.
* Add a dark-colored theme ``typhon-dark``.