### PR TITLE
Don't crash on scalar data variables with fill value set

### DIFF
--- a/typhon/files/handlers/common.py
+++ b/typhon/files/handlers/common.py
@@ -11,6 +11,7 @@ import warnings
 import netCDF4
 import pandas as pd
 import xarray as xr
+import numpy as np
 
 # The HDF4 file handler needs pyhdf, this might be very tricky to install if
 # you cannot use anaconda. Hence, I do not want it to be a hard dependency:
@@ -717,7 +718,10 @@ class NetCDF4(FileHandler):
             for var_name, var in group.variables.items():
                 if fields is None or path + var_name in fields:
                     dims = [dim_map[dim] for dim in var.dimensions]
-                    ds[path + var_name] = dims, var[:], dict(var.__dict__)
+                    if len(dims) == 0 and var[:] is np.ma.masked:
+                        ds[path + var_name] = dims, np.nan, dict(var.__dict__)
+                    else:
+                        ds[path + var_name] = dims, var[:], dict(var.__dict__)
         except RuntimeError:
             raise KeyError(f"Could not load the variable {path + var_name}!")
 

--- a/typhon/tests/files/handlers/test_netcdf4.py
+++ b/typhon/tests/files/handlers/test_netcdf4.py
@@ -57,6 +57,25 @@ class TestNetCDF4:
 
         assert after.equals(check)
 
+    def test_scalar_masked(self):
+        """Test if scalar masked values read OK
+
+        Test for issue #277
+        """
+
+        fh = NetCDF4()
+
+        with tempfile.TemporaryDirectory() as tdir:
+            tfile = os.path.join(tdir, "testfile.nc")
+            before = xr.Dataset(
+                    {"a":
+                        xr.DataArray(
+                            42,
+                            encoding={"_FillValue": 42})})
+            fh.write(before, tfile)
+            after = fh.read(tfile)
+            assert np.isnan(after["a"]) # fill value should become nan
+
     def test_times(self):
         """Test if times are read correctly
         """


### PR DESCRIPTION
Do not crash on scalar data variables that have a fill value set (see #277).

NB: so far this PR only contains a test that reproduces the problem!  It still needs more commits before it's ready to be merged!

I'm not yet sure how to fix it, open to ideas, in particular from @JohnMrziglod who knows this part of the code best.