### PR TITLE
Ensure NetCDF4 returns times correctly, even when scale factor is set.

### DIFF
--- a/typhon/files/handlers/common.py
+++ b/typhon/files/handlers/common.py
@@ -656,6 +656,8 @@ class NetCDF4(FileHandler):
         # xarray dataset.
 
         with netCDF4.Dataset(file_info.path, "r") as root:
+            # xarray decode_cf scales, don't do it twice!
+            root.set_auto_scale(False)
             dataset = xr.Dataset()
             self._load_group(dataset, None, root, fields)
 

--- a/typhon/tests/files/handlers/test_netcdf4.py
+++ b/typhon/tests/files/handlers/test_netcdf4.py
@@ -96,4 +96,4 @@ class TestNetCDF4:
                     "dtype": "int16"}
             fh.write(before, tfile)
             after = fh.read(tfile)
-            assert np.array_equal(before["a"], after["a"])
+            assert np.allclose(before["a"], after["a"])

--- a/typhon/tests/files/handlers/test_netcdf4.py
+++ b/typhon/tests/files/handlers/test_netcdf4.py
@@ -56,3 +56,24 @@ class TestNetCDF4:
             })
 
         assert after.equals(check)
+
+    def test_times(self):
+        """Test if times are read correctly
+        """
+
+        fh = NetCDF4()
+
+        with tempfile.TemporaryDirectory() as tdir:
+            tfile = os.path.join(tdir, "testfile.nc")
+            before = xr.Dataset(
+                    {"a":
+                        xr.DataArray(
+                            np.array(
+                                ["2019-02-14T09:00:00", "2019-02-14T09:00:01"],
+                                dtype="M8[ns]"))})
+            before["a"].encoding = {
+                    "units": "seconds since 2019-02-14 09:00:00",
+                    "scale_factor": 0.1}
+            fh.write(before, tfile)
+            after = fh.read(tfile)
+            assert np.array_equal(before["a"], after["a"])

--- a/typhon/tests/files/handlers/test_netcdf4.py
+++ b/typhon/tests/files/handlers/test_netcdf4.py
@@ -77,3 +77,23 @@ class TestNetCDF4:
             fh.write(before, tfile)
             after = fh.read(tfile)
             assert np.array_equal(before["a"], after["a"])
+
+    def test_scalefactor(self):
+        """Test if scale factors written/read correctly
+        """
+
+        fh = NetCDF4()
+
+        with tempfile.TemporaryDirectory() as tdir:
+            tfile = os.path.join(tdir, "testfile.nc")
+            before = xr.Dataset(
+                    {"a":
+                        xr.DataArray(
+                            np.array([0.1, 0.2]))})
+            before["a"].encoding = {
+                    "scale_factor": 0.1,
+                    "FillValue": 42,
+                    "dtype": "int16"}
+            fh.write(before, tfile)
+            after = fh.read(tfile)
+            assert np.array_equal(before["a"], after["a"])


### PR DESCRIPTION
The `NetCDF4` file handler reader seems to ignore scale factors for times (perhaps other fields too, I haven't tested that yet), in any case the times returned are incorrect.

This PR implements a fix (still in progress, so far just a test).