### PR TITLE
Improve calculation of saturation pressure for the mixed-phase

### DIFF
--- a/typhon/constants.py
+++ b/typhon/constants.py
@@ -11,6 +11,7 @@ Physical constants
 ``c``                           Speed of light in :math:`\sf ms^{-1}`
 ``N_A``                         Avogadro constant in :math:`\sf mol^{-1}`
 ``K``, ``zero_celsius``         Kelvin at 0 Celsius
+``triple_point_water``          Triple point temperature of water :math:`\sf K`
 ``R``                           Universal gas constant in
                                 :math:`\sf J mol^{-1}K{^-1}`
 ``molar_mass_dry_air``          Molar mass for dry air in
@@ -107,6 +108,7 @@ k = boltzmann = spc.Boltzmann  # J K^-1
 c = speed_of_light = spc.speed_of_light  # m s^-1
 N_A = avogadro = N = spc.Avogadro  # mol^-1
 K = zero_celsius = 273.15  # Kelvin at 0 Celsius
+triple_point_water = 273.16  # Triple point temperature in K
 R = gas_constant = spc.gas_constant  # J mol^-1 K^-1
 mu_B = spc.e * spc.Planck * (0.25 / spc.pi) / spc.m_e  # J T^-1
 molar_mass_dry_air = 28.9645e-3  # kg mol^-1

--- a/typhon/physics/atmosphere.py
+++ b/typhon/physics/atmosphere.py
@@ -26,6 +26,14 @@ def relative_humidity2vmr(RH, p, T, e_eq=None):
     .. math::
         VMR = \frac{RH \cdot e_s(T)}{p}
 
+    Note:
+        By default, the relative humidity is calculated with respect to
+        saturation over liquid water in accordance to the WMO standard for
+        radiosonde observations.
+        You can use :func:`~typhon.physics.e_eq_mixed_mk` to calculate
+        relative humidity with respect to saturation over the mixed-phase
+        following the IFS model documentation.
+
     Parameters:
         RH (float or ndarray): Relative humidity.
         p (float or ndarray): Pressue [Pa].
@@ -60,6 +68,14 @@ def vmr2relative_humidity(vmr, p, T, e_eq=None):
 
     .. math::
         RH = \frac{VMR \cdot p}{e_s(T)}
+
+    Note:
+        By default, the relative humidity is calculated with respect to
+        saturation over liquid water in accordance to the WMO standard for
+        radiosonde observations.
+        You can use :func:`~typhon.physics.e_eq_mixed_mk` to calculate
+        relative humidity with respect to saturation over the mixed-phase
+        following the IFS model documentation.
 
     Parameters:
         vmr (float or ndarray): Volume mixing ratio,


### PR DESCRIPTION
This PR:
* Redefines the calculation of the saturation pressure of water for the mixed phase
* Adds ``triple_point_water`` to the constants module
* Adds notes about WMO/IFS definitions of the relative humidity to related functions