### PR TITLE
Adding reading for Ppath

### DIFF
--- a/typhon/arts/catalogues.py
+++ b/typhon/arts/catalogues.py
@@ -20,7 +20,127 @@ __all__ = ['ArrayOfLineRecord',
            'SpeciesTag',
            'PropagationMatrix',
            'StokesVector',
+           'Ppath',
+           'GridPos',
            ]
+
+
+class GridPos:
+    """Representation of ARTS GridPos"""
+    
+    def __init__(self):
+        self.ind = None    # Index
+        self.next1 = None  # Numeric
+        self.next2 = None  # Numeric
+        
+    @classmethod
+    def from_xml(cls, xmlelement):
+        """Loads GridPos object from an existing file.
+        """
+        obj = cls()
+        
+        obj.ind = xmlelement[0].value()
+        obj.next1 = xmlelement[1].value()
+        obj.next2 = xmlelement[2].value()
+        
+        return obj
+    
+    def write_xml(self, xmlwriter, attr=None):
+        """Write GridPos object to an ARTS XML file.
+        """
+        if attr is None:
+            attr = {}
+
+        xmlwriter.open_tag("GridPos", attr)
+        xmlwriter.write_xml(self.ind)
+        xmlwriter.write_xml(self.next1)
+        xmlwriter.write_xml(self.next2)
+        xmlwriter.close_tag()
+    
+    def __repr__(self):
+        return "GridPos {}: n1={}; n2={}".format(self.ind, self.next1, self.next2)
+
+
+class Ppath:
+    """Represents the Ppath variable in ARTS"""
+    
+    def __init__(self):
+        self.dim = None          # Index
+        self.np = None           # Index
+        self.constant = None     # Numeric
+        self.background = None   # String
+        self.start_pos = None    # Vector
+        self.start_los = None    # Vector
+        self.start_lstep = None  # Numeric
+        self.pos = None          # Matrix
+        self.los = None          # Matrix
+        self.r = None            # Vector
+        self.lstep = None        # Vector
+        self.end_pos = None      # Vector
+        self.end_los = None      # Vector
+        self.end_lstep = None    # Vector
+        self.nreal = None        # Vector
+        self.ngroup = None       # Vector
+        self.gp_p = None         # ArrayOfGridPos
+        self.gp_lat = None       # ArrayOfGridPos
+        self.gp_lon = None       # ArrayOfGridPos
+    
+    def __repr__(self):
+        return "Ppath of {} steps in {}D Atmosphere".format(self.np, self.dim)
+    
+    @classmethod
+    def from_xml(cls, xmlelement):
+        """Loads Ppath object from an existing file.
+        """
+        obj = cls()
+        
+        obj.dim = xmlelement[0].value()
+        obj.np = xmlelement[1].value()
+        obj.constant = xmlelement[2].value()
+        obj.background = xmlelement[3].value()
+        obj.start_pos = xmlelement[4].value()
+        obj.start_los = xmlelement[5].value()
+        obj.start_lstep = xmlelement[6].value()
+        obj.pos = xmlelement[7].value()
+        obj.los = xmlelement[8].value()
+        obj.r = xmlelement[9].value()
+        obj.lstep = xmlelement[10].value()
+        obj.end_pos = xmlelement[11].value()
+        obj.end_los = xmlelement[12].value()
+        obj.end_lstep = xmlelement[13].value()
+        obj.nreal = xmlelement[14].value()
+        obj.ngroup = xmlelement[15].value()
+        obj.gp_p = xmlelement[16].value()
+        obj.gp_lat = xmlelement[17].value()
+        obj.gp_lon = xmlelement[18].value()
+        return obj
+    
+    def write_xml(self, xmlwriter, attr=None):
+        """Write Ppath object to an ARTS XML file.
+        """
+        if attr is None:
+            attr = {}
+
+        xmlwriter.open_tag("Ppath", attr)
+        xmlwriter.write_xml(self.dim)
+        xmlwriter.write_xml(self.np)
+        xmlwriter.write_xml(self.constant)
+        xmlwriter.write_xml(self.background)
+        xmlwriter.write_xml(self.start_pos)
+        xmlwriter.write_xml(self.start_los)
+        xmlwriter.write_xml(self.start_lstep)
+        xmlwriter.write_xml(self.pos)
+        xmlwriter.write_xml(self.los)
+        xmlwriter.write_xml(self.r)
+        xmlwriter.write_xml(self.end_pos)
+        xmlwriter.write_xml(self.end_los)
+        xmlwriter.write_xml(self.end_lstep)
+        xmlwriter.write_xml(self.nreal)
+        xmlwriter.write_xml(self.ngroup)
+        xmlwriter.write_xml(self.gp_p)
+        xmlwriter.write_xml(self.gp_lat)
+        xmlwriter.write_xml(self.gp_lon)
+        xmlwriter.close_tag()
 
 
 class ArrayOfLineRecord:

--- a/typhon/arts/catalogues.py
+++ b/typhon/arts/catalogues.py
@@ -39,7 +39,7 @@ class GridPos:
         """
         obj = cls()
         
-        obj.ind = xmlelement[0].value()
+        obj.ind = int(xmlelement[0].value())
         obj.next1 = xmlelement[1].value()
         obj.next2 = xmlelement[2].value()
         
@@ -52,9 +52,9 @@ class GridPos:
             attr = {}
 
         xmlwriter.open_tag("GridPos", attr)
-        xmlwriter.write_xml(self.ind)
-        xmlwriter.write_xml(self.next1)
-        xmlwriter.write_xml(self.next2)
+        xmlwriter.write_xml(self.ind, {"name": "OriginalGridIndexBelowInterpolationPoint"})
+        xmlwriter.write_xml(self.next1, {"name": "FractionalDistanceToNextPoint_1"})
+        xmlwriter.write_xml(self.next2, {"name": "FractionalDistanceToNextPoint_2"})
         xmlwriter.close_tag()
     
     def __repr__(self):
@@ -94,8 +94,8 @@ class Ppath:
         """
         obj = cls()
         
-        obj.dim = xmlelement[0].value()
-        obj.np = xmlelement[1].value()
+        obj.dim = int(xmlelement[0].value())
+        obj.np = int(xmlelement[1].value())
         obj.constant = xmlelement[2].value()
         obj.background = xmlelement[3].value()
         obj.start_pos = xmlelement[4].value()
@@ -122,24 +122,25 @@ class Ppath:
             attr = {}
 
         xmlwriter.open_tag("Ppath", attr)
-        xmlwriter.write_xml(self.dim)
-        xmlwriter.write_xml(self.np)
-        xmlwriter.write_xml(self.constant)
-        xmlwriter.write_xml(self.background)
-        xmlwriter.write_xml(self.start_pos)
-        xmlwriter.write_xml(self.start_los)
-        xmlwriter.write_xml(self.start_lstep)
-        xmlwriter.write_xml(self.pos)
-        xmlwriter.write_xml(self.los)
-        xmlwriter.write_xml(self.r)
-        xmlwriter.write_xml(self.end_pos)
-        xmlwriter.write_xml(self.end_los)
-        xmlwriter.write_xml(self.end_lstep)
-        xmlwriter.write_xml(self.nreal)
-        xmlwriter.write_xml(self.ngroup)
-        xmlwriter.write_xml(self.gp_p)
-        xmlwriter.write_xml(self.gp_lat)
-        xmlwriter.write_xml(self.gp_lon)
+        xmlwriter.write_xml(self.dim, {"name": "AtmosphericDimensionality"})
+        xmlwriter.write_xml(self.np, {"name": "NumberOfPositionInPropagationPath"})
+        xmlwriter.write_xml(self.constant, {"name": "PropagationPathConstant"})
+        xmlwriter.write_xml(self.background, {"name": "RadiativeBackground"})
+        xmlwriter.write_xml(self.start_pos, {"name": "StartPositionOfPropagationPath"})
+        xmlwriter.write_xml(self.start_los, {"name": "StartLOSOfPropagationPath"})
+        xmlwriter.write_xml(self.start_lstep, {"name": "StartLstepOfPropagationPath"})
+        xmlwriter.write_xml(self.pos, {"name": "PropagationPathPointPositions"})
+        xmlwriter.write_xml(self.los, {"name": "LineOfSight"})
+        xmlwriter.write_xml(self.r, {"name": "PropagationPathPointRadii"})
+        xmlwriter.write_xml(self.lstep, {"name": "PropagationPathPositionLength"})
+        xmlwriter.write_xml(self.end_pos, {"name": "EndPositionOfPropagationPath"})
+        xmlwriter.write_xml(self.end_los, {"name": "EndLOSOfPropagationPath"})
+        xmlwriter.write_xml(self.end_lstep, {"name": "EndLstepPropagationPath"})
+        xmlwriter.write_xml(self.nreal, {"name": "RefractiveIndexRealPart"})
+        xmlwriter.write_xml(self.ngroup, {"name": "GroupRefractiveIndex"})
+        xmlwriter.write_xml(self.gp_p, {"name": "PressureGridIndexPosition"}, arraytype="GridPos")
+        xmlwriter.write_xml(self.gp_lat, {"name": "LatitudeGridIndexPosition"}, arraytype="GridPos")
+        xmlwriter.write_xml(self.gp_lon, {"name": "LongitudeGridIndexPosition"}, arraytype="GridPos")
         xmlwriter.close_tag()
 
 

--- a/typhon/arts/types.py
+++ b/typhon/arts/types.py
@@ -27,6 +27,8 @@ from .catalogues import (ArrayOfLineRecord,
                          SpeciesTag,
                          PropagationMatrix,
                          StokesVector,
+                         Ppath,
+                         GridPos,
                          )
 from .internals import (ARTSCAT5,
                         Rational,
@@ -68,4 +70,6 @@ classes = {
     'XsecRecord': XsecRecord,
     'PropagationMatrix': PropagationMatrix,
     'StokesVector': StokesVector,
+    'Ppath': Ppath,
+    'GridPos': GridPos,
 }


### PR DESCRIPTION
I want to prototype some NLTE geometry in typhon.  I need to see Ppath from ARTS.  Here is a reading routine for Ppath.  I have tested and it reads 1D atmospheres well enough.  I have not tested more than this.

This code is not ready to be committed to main because of a major bug in the way typhon has designed its writing routine.  I cannot solve this, so I leave it as a pull request. Typhon does not accept zero-length arrays because it then cannot guess the type, but Ppath can have zero-length arrays for <3D atmospheres.  

I have therefore been unable to check whether ARTS can read the saved file.

How is this fixed?  Should we use special writing routines when we know the array-type, or can we add a keyword that is automatically used for zero-length arrays to "guide" typhon to the correct type, e.g., "variable_type=GridPos"?  The latter seems more friendly, but requires touching more files/routines.