### PR TITLE
Is this an OK addition to typhon.plots?

### DIFF
--- a/doc/typhon.plots.rst
+++ b/doc/typhon.plots.rst
@@ -40,6 +40,11 @@ plots
    sorted_legend_handles_labels
    styles
    supcolorbar
+   plot_ppath
+   plot_ppath_field
+   ppath_field_minmax_posbox
+   adjust_ppath_field_box_by_minmax
+   plot_ppath_field_zenith_coverage_per_gp_p
 
 Typhon named colors
 ^^^^^^^^^^^^^^^^^^^

--- a/typhon/arts/catalogues.py
+++ b/typhon/arts/catalogues.py
@@ -28,10 +28,10 @@ __all__ = ['ArrayOfLineRecord',
 class GridPos:
     """Representation of ARTS GridPos"""
     
-    def __init__(self):
-        self.ind = None    # Index
-        self.next1 = None  # Numeric
-        self.next2 = None  # Numeric
+    def __init__(self, ind=None, n1=None, n2=None):
+        self.ind = ind  # Index
+        self.n1 = n1    # Numeric
+        self.n2 = n2    # Numeric
         
     @classmethod
     def from_xml(cls, xmlelement):
@@ -40,8 +40,8 @@ class GridPos:
         obj = cls()
         
         obj.ind = int(xmlelement[0].value())
-        obj.next1 = xmlelement[1].value()
-        obj.next2 = xmlelement[2].value()
+        obj.n1 = xmlelement[1].value()
+        obj.n2 = xmlelement[2].value()
         
         return obj
     
@@ -53,12 +53,18 @@ class GridPos:
 
         xmlwriter.open_tag("GridPos", attr)
         xmlwriter.write_xml(self.ind, {"name": "OriginalGridIndexBelowInterpolationPoint"})
-        xmlwriter.write_xml(self.next1, {"name": "FractionalDistanceToNextPoint_1"})
-        xmlwriter.write_xml(self.next2, {"name": "FractionalDistanceToNextPoint_2"})
+        xmlwriter.write_xml(self.n1, {"name": "FractionalDistanceToNextPoint_1"})
+        xmlwriter.write_xml(self.n2, {"name": "FractionalDistanceToNextPoint_2"})
         xmlwriter.close_tag()
     
     def __repr__(self):
-        return "GridPos {}: n1={}; n2={}".format(self.ind, self.next1, self.next2)
+        return "GridPos {}: n1={}; n2={}".format(self.ind, self.n1, self.n2)
+    
+    def __eq__(self, other):
+        return self.ind == other.ind and self.n1 == other.n1 and self.n2 == other.n2
+    
+    def __ne__(self, other):
+        return not (self==other)
 
 
 class Ppath:
@@ -142,6 +148,16 @@ class Ppath:
         xmlwriter.write_xml(self.gp_lat, {"name": "LatitudeGridIndexPosition"}, arraytype="GridPos")
         xmlwriter.write_xml(self.gp_lon, {"name": "LongitudeGridIndexPosition"}, arraytype="GridPos")
         xmlwriter.close_tag()
+        
+    def alt_lat_lon_za_aa(self):
+        alt = self.pos[:, 0]
+        lat = self.pos[:, 1] if self.pos.shape[1] > 1 else np.zeros_like(alt)
+        lon = self.pos[:, 2] if self.pos.shape[1] > 2 else np.zeros_like(alt)
+        
+        za = self.los[:, 0]
+        aa = self.los[:, 1] if self.los.shape[1] > 1 else np.zeros_like(za)
+        
+        return alt, lat, lon, za, aa
 
 
 class ArrayOfLineRecord:

--- a/typhon/plots/__init__.py
+++ b/typhon/plots/__init__.py
@@ -9,6 +9,7 @@ from typhon.plots.common import *  # noqa
 from typhon.plots.formatter import *  # noqa
 from typhon.plots.plots import *  # noqa
 from typhon.plots.arts_lookup import *  # noqa
+from typhon.plots.ppath import *  # noqa
 try:
     from typhon.plots.maps import *  # noqa
 except ImportError:

--- a/typhon/plots/ppath.py
+++ b/typhon/plots/ppath.py
@@ -111,7 +111,7 @@ def plot_ppath_field(ppath_field, planetary_radius=1, lat_is_x=True,
     n2 = n1 if np.isclose(n1*n1, subplots) or n1*n1 > subplots else n1 + 1
     
     if axes is None:
-        fig = plt.figure()
+        fig = plt.gcf()
         axes = []
         for i in range(subplots):
             axes.append(fig.add_subplot(n1, n2, i+1, projection='polar'))
@@ -264,7 +264,7 @@ def plot_ppath_field_zenith_coverage_per_gp_p(ppath_field, scale_alt=1000, axes=
     n2 = n1 if np.isclose(n1*n1, N) or n1*n1 > N else n1 + 1
     
     if axes is None:
-        fig = plt.figure()
+        fig = plt.gcf()
         axes = []
         for i in range(N):
             axes.append(fig.add_subplot(n1, n2, i+1, projection='polar'))

--- a/typhon/plots/ppath.py
+++ b/typhon/plots/ppath.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+
+"""Functions to create plots using matplotlib.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+__all__ = [
+    'plot_ppath',
+    'plot_ppath_field',
+    'ppath_field_minmax_posbox',
+    'adjust_ppath_field_box_by_minmax',
+    'plot_ppath_field_zenith_coverage_per_gp_p',
+]
+
+
+def plot_ppath(ax, ppath, planetary_radius=1, lat_is_x=True, scale_alt=1000):
+    """ Return the ARTS Ppath plotted on the surface
+    
+    Parameters:
+        ax:
+            (AxesSubplot): matplotlib axes to plot into.  Assumes polar project
+        ppath:
+            (Ppath or Workspace)  Propagation path or Wosrkspace with the path
+        planetary_radius:
+            (Numeric)  Spherical radius of the planetary body (if ppath_field is not Workspace)
+        lat_is_x:
+            (Boolean) Have lat or lon act as the x-coordinate?
+        scale_alt:
+            (Numeric) Divide altitude and planetary_radius by this value
+    """
+    
+    try:
+        ppath = ppath.ppath.value
+    except:
+        pass
+    
+    try:
+        planetary_radius = ppath.refellipsoid.value[0]
+    except:
+        pass
+    
+    alt, lat, lon, za, aa = ppath.alt_lat_lon_za_aa()
+    
+    if lat_is_x:
+        x = lat
+    else:
+        x = lon
+    
+    ax.plot(np.deg2rad(x), alt/scale_alt)
+    ax.set_rorigin(-planetary_radius/scale_alt)
+
+
+def plot_ppath_field(ppath_field, planetary_radius=1, lat_is_x=True,
+                     scale_alt=1000, subplots=1):
+    """ Return the ARTS Ppath plotted on the surface
+    
+    Parameters:
+        ppath_field:
+            (Ppath or Workspace)  Propagation path or Wosrkspace with the path
+        planetary_radius:
+            (Numeric)  Spherical radius of the planetary body (if ppath_field is not Workspace)
+        lat_is_x:
+            (Boolean) Have lat or lon act as the x-coordinate?
+        scale_alt:
+            (Numeric) Divide altitude and planetary_radius by this value
+        subplots:
+            (Index)  Divides the ppath_field into this many equally long
+            segments, so that the first len(ppath_field) // subplots plots
+            are drawn on the same surface and so forth
+    
+    Returns:
+        list of axis of the length of subplots
+    """
+    
+    try:
+        ppath_field = ppath_field.ppath_field.value
+    except:
+        pass
+    
+    try:
+        planetary_radius = ppath_field.refellipsoid.value[0]
+    except:
+        pass
+    
+    N = len(ppath_field)
+    if N % subplots != 0:
+        raise RuntimeError("Bad inputs. Only for evenly divisible numbers")
+    
+    # Number of drawings per subplot
+    n = N // subplots
+    path_ind = 0
+    
+    n1 = int(np.ceil(np.sqrt(subplots)))
+    n2 = n1 if np.isclose(n1*n1, subplots) or n1*n1 > subplots else n1 + 1
+    
+    axes = []
+    for i in range(subplots):
+        axes.append(plt.subplot(n1, n2, i+1, projection='polar'))
+        for j in range(n):
+            plot_ppath(axes[-1], ppath_field[path_ind], 
+                       planetary_radius, lat_is_x, scale_alt)
+            path_ind += 1
+    return axes
+
+
+def ppath_field_minmax_posbox(ppath_field):
+    """ Return the minimum and maximum of all pos variables of ppath_field
+    
+    Parameters:
+        ppath_field:
+            (Ppath or Workspace)  Propagation path or Wosrkspace with the path
+    
+    Returns:
+        min(alt), max(alt), min(lat), max(lat), min(lon), max(lon)
+    """
+    
+    try:
+        ppath_field = ppath_field.ppath_field.value
+    except:
+        pass
+    
+    minalt = minlat = minlon = np.infty
+    maxalt = maxlat = maxlon = -np.infty
+    
+    for ppath in ppath_field:
+        alt, lat, lon, za, aa = ppath.alt_lat_lon_za_aa()
+        
+        minalt = min(alt.min(), minalt)
+        maxalt = max(alt.max(), maxalt)
+        
+        minlat = min(lat.min(), minlat)
+        maxlat = max(lat.max(), maxlat)
+        
+        minlon = min(lon.min(), minlon)
+        maxlon = max(lon.max(), maxlon)
+        
+    return minalt, maxalt, minlat, maxlat, minlon, maxlon
+
+
+def adjust_ppath_field_box_by_minmax(axes, ppath_field, lat_is_x=True,
+                                     scale_alt=1000, extrap=0.05):
+    """ Adjusts the axis of plotted ppath_field to 
+    
+    Parameters:
+        axes:
+            Plotted axes of ppath_field
+        ppath_field:
+            (Ppath or Workspace)  Propagation path or Wosrkspace with the path
+        planetary_radius:
+            (Numeric)  Spherical radius of the planetary body (if ppath_field is not Workspace)
+        lat_is_x:
+            (Boolean) Have lat or lon act as the x-coordinate?
+        scale_alt:
+            (Numeric) Divide altitude and planetary_radius by this value
+        extrap:
+            (Numeric) How large an extrapolation of the box in terms of full
+            posbox minmax
+    """
+    
+    minalt, maxalt, minlat, maxlat, minlon, maxlon = ppath_field_minmax_posbox(ppath_field)
+    
+    if lat_is_x:
+        xmin = minlat
+        xmax = maxlat
+        max_diff = 180
+    else:
+        xmin = minlon
+        xmax = maxlon
+        max_diff = 360
+    dx = (xmax-xmin) * extrap
+    
+    xmin -= dx
+    xmax += dx
+    
+    if (xmax-xmin) > max_diff:
+        return  # no adjustment possible
+    
+    for ax in axes:
+        ax.set_thetamin(xmin)
+        ax.set_thetamax(xmax)
+
+
+def wzeniths(zeniths):
+    n = len(zeniths)
+    if not n:
+        return np.array([0, 180]), np.array([1, 1])
+    inds = np.argsort(zeniths)
+    zaz = np.deg2rad(zeniths[inds])
+    cz = np.cos(zaz)
+    
+    wz = np.zeros((3*n))
+    za = np.zeros((3*n))
+    for i in range(n-1):
+        N = i*3
+        za[0+N] = zaz[i]
+        za[1+N] = 0.5 * (zaz[i] + zaz[i+1])
+        za[2+N] = zaz[i+1]
+        
+        w = 0.5 * (cz[i] - cz[i+1])
+        wz[0+N] = wz[1+N] = wz[2+N] = w
+    
+    za[-1] = np.deg2rad(180)
+    return za, wz
+
+
+def plot_ppath_field_zenith_coverage_per_gp_p(ppath_field, scale_alt=1000):
+    """Plots the zenith angle coverage of a ppath_field for all the altitudes
+    in the field.
+    
+    Parameters:
+        ppath_field:
+            (Ppath or Workspace)  Propagation path or Wosrkspace with the path
+        scale_alt:
+            (Numeric) Divide altitude and planetary_radius by this value
+    
+    Returns:
+        list of axis, list of altitudes, list of maximum weights
+    """
+    try:
+        ppath_field = ppath_field.ppath_field.value
+    except:
+        pass
+    
+    alt = []
+    gps = []
+    for path in ppath_field:
+        for i in range(path.np):
+            if path.gp_p[i] not in gps:
+                gps.append(path.gp_p[i])
+                alt.append(path.pos[i, 0])
+    alt = np.array(alt)
+    
+    # Size of subplots
+    N = len(alt)
+    
+    zas = np.full((N), None)
+    for path in ppath_field:
+        for i in range(path.np):
+            ip = np.where(path.pos[i, 0] == alt)[0][0]
+            if zas[ip]:
+                zas[ip].append(path.los[i, 0])
+            else:
+                zas[ip] = [path.los[i, 0]]
+            
+    # Sub-plot grid
+    n1 = int(np.ceil(np.sqrt(N)))
+    n2 = n1 if np.isclose(n1*n1, N) or n1*n1 > N else n1 + 1
+    
+    inds = np.argsort(alt)
+    
+    axes = []
+    wei = []
+    alts = []
+    for i in range(N):
+        pos = inds[i]
+        za, wz = wzeniths(np.array(zas[pos]))
+        
+        wei.append(wz.max())
+        alts.append(alt[pos])
+        
+        axes.append(plt.subplot(n1, n2, i+1, projection='polar'))
+        axes[-1].plot(za, wz,'k')
+        axes[-1].set_rorigin(-0.25/np.pi)
+        axes[-1].set_thetamin(0)
+        axes[-1].set_thetamax(180)
+        axes[-1].set_rgrids([0, wz.max()*1.05], ['', ''])
+        axes[-1].set_thetagrids([0, 90, 180], ['Zenith', 'Limb', 'Nadir'])
+        axes[-1].set_title("Alt {} km".format(alt[pos]/scale_alt))
+    
+    return axes, alts, wei


### PR DESCRIPTION
Hi,

Here are some functions to easily plot the ARTS Ppath variables.  The intent is:  the functions should take either a typhon or Workspace variables.  The field-variables will draw the entire thing to the global figure, whereas the non-array singular variables will be drawn to the local axis, so long as it is polarly projected.

There are probably plenty of bugs.  And the code is definitely not python-esque.

The intent of the functions are:

plot_ppath, which plots on an axis the ppath.  If the main input parameter is an ARTS workspace, it extracts radius and ppath from it before plotting.  Returns nothing

plot_ppath_field:  Calls the above multiple times.  If the main variable is a Workspace variable it will use the variables in ARTS.  Returns the axes it draws on, which might be more than one since ppath_field is generated from various geometries in ARTS so it fits to have it divided by those geometries.

ppath_field_minmax_posbox:  Finds and returns min and max of the position space.

adjust_ppath_field_box_by_minmax:  Uses the above to adjust so not the whole field is drawn.

plot_ppath_field_zenith_coverage_per_gp_p: Plots a massive drawing of the weighted coverage of the zenith space of the ppath_field.  I.e., at each altitude it shows the weight of each individual ppath in ppath_field to the spherical integration.  Returns axes and some housekeeping since drawing distances cannot be shown (too much clutter, so the returned weights helps determine if the 1D 'spherical' coverage is good.