### PR TITLE
Error correction.  ARTS treats LM_AER as 13 numbers since it is inter…

### DIFF
--- a/typhon/arts/internals.py
+++ b/typhon/arts/internals.py
@@ -167,7 +167,7 @@ class LineFunctionsData:
     @staticmethod
     def len_of_key(key):
         if key in ["LM_AER"]:
-            return 12
+            return 13
         elif key in ["#"]:
             return 0
         elif key in ["T0"]:


### PR DESCRIPTION
…polated internally.