### PR TITLE
Add Python 3.7 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+dist: xenial  # required for Python >= 3.7
 language: python
 python:
   - 3.6
+  - 3.7
 env:
   - CONFIG=TEST
   - CONFIG=PEP8


### PR DESCRIPTION
This PR [enables Python 3.7](https://docs.travis-ci.com/user/languages/python/#python-37-and-higher) in the Travis CI build matrix.