### PR TITLE
Revert "Ensure that passed array are contiguous..."

### DIFF
--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -224,13 +224,6 @@ class VariableValueStruct(c.Structure):
             ptr = c.cast(c.c_char_p(value.encode()), c.c_void_p)
         # Vector, Matrix
         elif type(value) == np.ndarray:
-
-            # Need to make a copy of the array if it is not contiguous.
-            if not value.flags["C_CONTIGUOUS"]:
-                self._value = np.array(value, copy = True, dtype = np.float64, order = "C")
-                value = self._value
-
-            value = np.array(value, dtype = np.float64, )
             if value.dtype == np.float64:
                 ptr = value.ctypes.data
                 for i in range(value.ndim):

--- a/typhon/tests/arts/test_workspace.py
+++ b/typhon/tests/arts/test_workspace.py
@@ -159,36 +159,31 @@ class TestWorkspace:
             self.ws.Copy(self.ws.string_wsv, self.ws.numeric_wsv)
 
     def test_tensor_3(self):
-        f = np.random.choice(["C", "F"])
-        t_0 = np.array(np.random.rand(*([3] * 3)), order = f)
+        t_0 = np.random.rand(*([3] * 3))
         self.ws.Tensor3Create("tensor_3")
         self.ws.tensor_3 = t_0
         assert np.all(t_0 == self.ws.tensor_3.value)
 
     def test_tensor_4(self):
-        f = np.random.choice(["C", "F"])
-        t_0 = np.array(np.random.rand(*([3] * 4)), order = f)
+        t_0 = np.random.rand(*([3] * 4))
         t_1 = self.ws.Tensor4Create("tensor_4")
         self.ws.tensor_4 = t_0
         assert np.all(t_0 == self.ws.tensor_4.value)
 
     def test_tensor_5(self):
-        f = np.random.choice(["C", "F"])
-        t_0 = np.array(np.random.rand(*([3] * 5)), order = f)
+        t_0 = np.random.rand(*([3] * 5))
         t_1 = self.ws.Tensor5Create("tensor_5")
         self.ws.tensor_5 = t_0
         assert np.all(t_0 == self.ws.tensor_5.value)
 
     def test_tensor_6(self):
-        f = np.random.choice(["C", "F"])
-        t_0 = np.array(np.random.rand(*([3] * 6)), order = f)
+        t_0 = np.random.rand(*([3] * 6))
         t_1 = self.ws.Tensor6Create("tensor_6")
         self.ws.tensor_6 = t_0
         assert np.all(t_0 == self.ws.tensor_6.value)
 
     def test_tensor_7(self):
-        f = np.random.choice(["C", "F"])
-        t_0 = np.array(np.random.rand(*([3] * 7)), order = f)
+        t_0 = np.random.rand(*([3] * 7))
         self.ws.Tensor7Create("tensor_7")
         self.ws.tensor_7 = t_0
         assert np.all(t_0 == self.ws.tensor_7.value)


### PR DESCRIPTION
This reverts commit c2655f6545dca921e523370a8194de3b8e11bf5b.

Arrays with more than 127 elements were partially uninitialized after
that commit.

Test on linux:

import typhon
from typhon.arts.workspace import Workspace
import numpy as np
arts = Workspace(3, 3)
arts.f_grid = np.linspace(1.75e13, 4e14, 128)
print(arts.f_grid.value[0:6])

Before revert:

[6.90303235e-310 6.90303235e-310 3.17051490e-316 3.17051490e-316
 2.95472441e+013 3.25590551e+013]

After revert:

[1.75000000e+13 2.05118110e+13 2.35236220e+13 2.65354331e+13
 2.95472441e+13 3.25590551e+13]