### PR TITLE
Fix appveyor... again

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,7 @@ install:
   - pip install Cython
   - pip install pytest
   - pip install git+https://github.com/Unidata/cftime
+  - pip install netCDF4==1.5.0
   - pip install .
   - git clone --depth=1 https://github.com/atmtools/typhon-testfiles.git
   - "set TYPHONTESTFILES=%cd%\\typhon-testfiles"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ init:
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - C:\\Miniconda36-x64\\python.exe -m pip install -U pip
-  - pip install numpy==1.15.4
+  - pip install numpy==1.16.3
   - pip install Cython
   - pip install pytest
   - pip install git+https://github.com/Unidata/cftime


### PR DESCRIPTION
Newer NetCDF4 package installation fails due to missing binary wheel.