### PR TITLE
Ensure contiguous arrays

### DIFF
--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -224,6 +224,9 @@ class VariableValueStruct(c.Structure):
             ptr = c.cast(c.c_char_p(value.encode()), c.c_void_p)
         # Vector, Matrix
         elif type(value) == np.ndarray:
+            # arrays need to be contiguous when passed to the ARTS API
+            value = np.ascontiguousarray(value)
+
             if value.dtype == np.float64:
                 ptr = value.ctypes.data
                 for i in range(value.ndim):
@@ -253,6 +256,7 @@ class VariableValueStruct(c.Structure):
                 ptr = c.cast(c.pointer((c.c_long * len(value))(*value)), c.c_void_p)
             dimensions[0] = len(value)
 
+        self._value = value
         self.ptr = ptr
         self.initialized = initialized
         self.dimensions  = (c.c_long * 7)(*dimensions)

--- a/typhon/tests/arts/test_workspace.py
+++ b/typhon/tests/arts/test_workspace.py
@@ -313,3 +313,16 @@ class TestWorkspace:
         agenda.execute(self.ws)
 
         assert self.ws.stokes_dim.value == 42
+
+    def test_contiguous_arrays(self):
+        x = np.linspace(0, 1, 256)
+
+        xf = np.asarray(x, order='F')
+        self.ws.f_grid = xf
+        assert np.array_equal(self.ws.f_grid.value, xf)
+
+        self.ws.f_grid = x[::2]
+        assert np.array_equal(self.ws.f_grid.value, x[::2])
+
+        self.ws.f_grid = np.ascontiguousarray(x[::2])
+        assert np.array_equal(self.ws.f_grid.value, x[::2])


### PR DESCRIPTION
This PR fixes #301 

Ensure that arrays that are passed to the ARTS API are contiguous. In addition, a reference to the passed value is kept to ensure that the memory is not deallocated.