### PR TITLE
Replace ``print`` statements with proper ``logging``

### DIFF
--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -69,7 +69,7 @@ Adding functions / classes
 --------------------------
 
 When you add a new function or class, you also have to add its name the
-corresponing rst file in the doc/ folder.
+corresponding rst file in the doc/ folder.
 
 Common module names
 -------------------
@@ -82,3 +82,22 @@ external modules::
   import matplotlib as mpl
   import matplotlib.pyplot as plt
 
+
+Logging
+-------
+
+The standard :mod:`logging` module is used to create log messages. Make sure
+to use an appropriate log level for your message. The default level,
+comparable to a ``print``, should be ``logging.INFO``::
+
+    logger = logging.getLogger(__name__)
+    logger.info('Common log message.')
+
+In rare occasions, the ``print`` function may be used, if the output gives
+additional information to the user that exceeds the scope of a log. In those
+cases, the additional output has to be guarded by a ``verbose`` keyword
+which defaults to ``False``::
+
+    def function(verbose=False):
+        if verbose:
+            print('Message to stdout'.)

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ It provides:
 Further information on ARTS can be found on http://www.radiativetransfer.org/.
 """
 
+import logging
 import sys
 import subprocess
 
@@ -38,8 +39,9 @@ try:
     __version__ = so.strip().decode("ascii").lstrip("v").replace(
         "-", "+dev", 1).replace("-", ".")
 except subprocess.CalledProcessError:
-    print("Warning: could not determine version from git, extracting "
-        " latest release version from source", file=sys.stderr)
+    logging.warning(
+        "Warning: could not determine version from git, extracting "
+        " latest release version from source")
 
     # Partse version number from module-level ASCII file. This prevents
     # double-entry bookkeeping).

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -66,3 +66,26 @@ def set_loglevel(level, handler=None, formatter=None):
     """
     _logger.setLevel(level)
     _ensure_handler(handler, formatter).setLevel(level)
+
+
+def set_fancy_logging(level=None):
+    """Create a basic logging config with colorful output format."""
+    color = "\033[1;%dm"
+    reset = "\033[0m"
+    black, red, green, yellow, blue, magenta, cyan, white = [
+        color % (30 + i) for i in range(8)]
+    logformat = (
+        '['
+        f'{magenta}%(levelname)s{reset}:'
+        f'{red}%(asctime)s.%(msecs)03d{reset}:'
+        f'{yellow}%(filename)s{reset}'
+        f':{blue}%(lineno)s{reset}'
+        f':{green}%(funcName)s{reset}'
+        f'] %(message)s'
+    )
+
+    logging.basicConfig(
+        format=logformat,
+        level=level if level is not None else logging.INFO,
+        datefmt = '%H:%M:%S',
+    )

--- a/typhon/__init__.py
+++ b/typhon/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+import functools
+import logging
 
 from .version import __version__
 
@@ -31,3 +32,37 @@ if not __TYPHON_SETUP__:
         import pytest
 
         return pytest.main(['--pyargs', 'typhon.tests'])
+
+
+_logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache()
+def _ensure_handler(handler=None, formatter=None):
+    """Make sure that a handler is attached to the root logger.
+
+    The LRU cache ensures that a new handler is only created during the
+    first call of the function. From then on, this handler is reused.
+    """
+    if handler is None:
+        handler = logging.StreamHandler()
+
+    if formatter is None:
+        formatter = logging.Formatter(logging.BASIC_FORMAT)
+
+    handler.setFormatter(formatter)
+    _logger.addHandler(handler)
+
+    return handler
+
+
+def set_loglevel(level, handler=None, formatter=None):
+    """Set the loglevel of the package.
+
+    Parameters:
+        level (int): Loglevel according to the ``logging`` module.
+        handler (``logging.Handler``): Logging handler.
+        formatter (``logging.Formatter``): Logging formatter.
+    """
+    _logger.setLevel(level)
+    _ensure_handler(handler, formatter).setLevel(level)

--- a/typhon/arts/workspace/__init__.py
+++ b/typhon/arts/workspace/__init__.py
@@ -95,12 +95,16 @@ numpy.asarray.
 
 """
 
-from warnings import warn
+import logging
 
 from typhon.environment import environ
 
+
+logger = logging.getLogger(__name__)
+
 if environ.get('ARTS_BUILD_PATH') is None:
-    warn("ARTS_BUILD_PATH environment variable required to locate ARTS API.")
+    logger.warning(
+        "ARTS_BUILD_PATH environment variable required to locate ARTS API.")
 else:
     from typhon.arts.workspace.workspace import Workspace, arts_agenda, Include
     from typhon.arts.workspace.variables import WorkspaceVariable

--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -20,12 +20,16 @@ Attributes:
 """
 
 import ctypes as c
-import numpy  as np
-import scipy  as sp
+import logging
 import os
+
+import numpy as np
+import scipy as sp
 
 from typhon.environment import environ
 
+
+logger = logging.getLogger(__name__)
 
 ################################################################################
 # Version Requirements
@@ -46,7 +50,7 @@ if environ.get("ARTS_BUILD_PATH") is None:
 try:
     lib_path = os.path.join(environ.get("ARTS_BUILD_PATH"), "src",
                             "libarts_api.so")
-    print("Loading ARTS API from: " + lib_path)
+    logging.info("Loading ARTS API from: " + lib_path)
     arts_api = c.cdll.LoadLibrary(lib_path)
 except:
     raise EnvironmentError("Could not find ARTS API in your ARTS build path. "

--- a/typhon/arts/workspace/api.py
+++ b/typhon/arts/workspace/api.py
@@ -50,7 +50,7 @@ if environ.get("ARTS_BUILD_PATH") is None:
 try:
     lib_path = os.path.join(environ.get("ARTS_BUILD_PATH"), "src",
                             "libarts_api.so")
-    logging.info("Loading ARTS API from: " + lib_path)
+    logger.info("Loading ARTS API from: " + lib_path)
     arts_api = c.cdll.LoadLibrary(lib_path)
 except:
     raise EnvironmentError("Could not find ARTS API in your ARTS build path. "

--- a/typhon/arts/workspace/workspace.py
+++ b/typhon/arts/workspace/workspace.py
@@ -10,6 +10,7 @@ Attributes:
 
 """
 import ctypes as c
+import logging
 import numpy  as np
 
 import ast
@@ -34,6 +35,8 @@ from typhon.arts.workspace.utility import unindent
 
 imports = dict()
 
+
+logger = logging.getLogger(__name__)
 
 ################################################################################
 # ARTS Agenda Macro
@@ -130,7 +133,7 @@ def arts_agenda(func):
                 context[arg_name].ptr = ptr
                 eval(compile(m , "<unknown>", 'exec'), context)
             except Exception as e:
-                print(r"Exception in Python callback:\n", e)
+                logger.error(r"Exception in Python callback:\n", e)
             context[arg_name].ptr = None
 
         callback_body = []

--- a/typhon/cloudmask/aster.py
+++ b/typhon/cloudmask/aster.py
@@ -2,6 +2,7 @@
 """Functions to work with ASTER L1B satellite data.
 """
 import datetime
+import logging
 import os
 from collections import namedtuple
 
@@ -20,6 +21,8 @@ __all__ = [
     'get_reflection_angle',
     'theta_r',
 ]
+
+logger = logging.getLogger(__name__)
 
 
 class ASTERimage:
@@ -444,7 +447,8 @@ def cloudtopheight_IR(cloudmask, Tb14, method='simple', latitudes=None,
                                                   resolution_ratio, axis=0),
                                                   resolution_ratio, axis=1)
         except ValueError:
-            print('Problems matching the shapes of cloudmask and Tb14.')
+            logger.warning(
+                'Problems matching the shapes of cloudmask and Tb14.')
     else:
         mask_cloudy = cloudmask.copy()
         mask_clear = cloudmask_inverted.copy()

--- a/typhon/collocations/common.py
+++ b/typhon/collocations/common.py
@@ -6,6 +6,8 @@ atmlab implemented by Gerrit Holl.
 Created by John Mrziglod, June 2017
 """
 
+import logging
+
 import numba
 import numpy as np
 from typhon.files import FileSet
@@ -20,6 +22,8 @@ __all__ = [
     "Collocations",
     "expand",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 class Collocations(FileSet):
@@ -120,9 +124,7 @@ class Collocations(FileSet):
                 f"(default), 'expand' or 'compact'."
             )
 
-    def search(
-            self, filesets, collocator=None, log_dir=None, verbose=1,
-            **kwargs):
+    def search(self, filesets, collocator=None, **kwargs):
         """Find all collocations between two filesets and store them in files
 
         Collocations are two or more data points that are located close to each
@@ -155,9 +157,6 @@ class Collocations(FileSet):
             collocator: If you want to use your own collocator, you can pass it
                 here. It must behave like
                 :class:`~typhon.collocations.collocator.Collocator`.
-            log_dir: If given, the log files for the processes will be stored
-                in this directory.
-            verbose: If true, it prints logging messages.
             **kwargs: Additional keyword arguments that are allowed for
                 :meth:`~typhon.collocations.collocator.Collocator.collocate_filesets`.
 
@@ -199,11 +198,10 @@ class Collocations(FileSet):
             collocations.search(
                 [seviri, mhs], start="2013-12-10", end="20 Dec 2013",
                 processes=10, max_interval="5 min", max_distance="5 km",
-                verbose=2,
             )
         """
         if collocator is None:
-            collocator = Collocator(verbose=verbose)
+            collocator = Collocator()
 
         collocated_files = collocator.collocate_filesets(
             filesets, output=self, **kwargs
@@ -212,7 +210,7 @@ class Collocations(FileSet):
         timer = Timer().start()
         for _ in collocated_files:
             pass
-        print(f"{timer} for finding all collocations")
+        logger.info(f"{timer} for finding all collocations")
 
 
 @numba.jit

--- a/typhon/datasets/tovs.py
+++ b/typhon/datasets/tovs.py
@@ -30,14 +30,18 @@ try:
     import progressbar
 except ImportError:
     progressbar = None
- 
+
+
+logger = logging.getLogger(__name__)
+
 try:
     import coda
 except ImportError:
-    print("Unable to import coda, won't read IASI EPS L1C. "
+    logger.warning(
+        "Unable to import coda, won't read IASI EPS L1C. "
         "If you need to read IASI EPS L1C, please obtain CODA from "
         "http://stcorp.nl/coda/ and install.  Good luck.",
-        file=sys.stderr)
+        )
     
 from . import dataset
 from ..utils import safe_eval
@@ -53,8 +57,6 @@ from .. import config
 from . import filters
 
 from . import _tovs_defs
-
-logger = logging.getLogger(__name__)
 
 def _noaa_names(i):
     """Return set of possible NOAA names for sat number

--- a/typhon/nonlte/nonltecalc/__init__.py
+++ b/typhon/nonlte/nonltecalc/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import logging
+
 import numpy as np
 import pylab as plt
 from scipy.constants import c, k, h
@@ -10,6 +12,10 @@ from ..spectra.abscoeff import basic
 from ..rtc import SOSC, FOSC
 from ..spectra.lineshape import DopplerWind
 from typhon.physics.em import planck, rayleighjeans
+
+
+logger = logging.getLogger(__name__)
+
 
 def calcu_grid(radius, alt_ref, angle=False, speed=None):
     """ Calculation grid for given altitude and radius
@@ -564,7 +570,7 @@ def Calc(Ite_pop, Abs_ite,
                 lambda_approx_out[xx, i, ((Mu_tangent > Alt_ref[i])), :] = 0
 #                ji_in_all[xx, i, ((Mu_tangent > Alt_ref[i-1])), :] = 0
                 if np.argwhere(Mu_tangent == Alt_ref[i]).size!=1:
-                    print (i,xx,"error!")
+                    logger.error(' '.join((i, xx, "error!")))
 
             elif i == Alt_ref.size-1:  # FOSC
                 tl_1 = Abs_coeff[i] * F_vl_i[xx][i]
@@ -582,7 +588,7 @@ def Calc(Ite_pop, Abs_ite,
                                  Bul[up_tag, low_tag],
                                  Freq_array[xx]*1.e9)*F_vl_i[xx][i-1]
                 else:
-                    print('Type iteration method')
+                    raise ValueError(f'Invalid iteration method {iteration}')
                 # tdl2 = calc_abscoeff(xx, IteNum+1, i-1) * F_vl_i[xx][i-1]
                 tl1 = (0.5*np.abs(tl_1+tl_2).reshape((1, Fre_range.size)) *
                        PSC2[:, i-1].reshape((Mu_tangent.size, 1)))  # (Mu, Fre)
@@ -679,11 +685,13 @@ def Calc(Ite_pop, Abs_ite,
                              weighttemp,
                              axis=0)*0.5
                 if (L_ap>1) or (L_ap<0):
-                    print(L_ap, i, 
-                          lambda_approx_in[xx, i, :, :].min(),
-                          lambda_approx_out[xx, i, :, :].min(),
-                          lambda_approx_in[xx, i, :, :].max(),
-                          lambda_approx_out[xx, i, :, :].mmx())
+                    logger.info(
+                        L_ap, i,
+                        lambda_approx_in[xx, i, :, :].min(),
+                        lambda_approx_out[xx, i, :, :].min(),
+                        lambda_approx_in[xx, i, :, :].max(),
+                        lambda_approx_out[xx, i, :, :].mmx()
+                    )
                     L_ap[L_ap<0]=0
                     L_ap[L_ap>1]=1
                 #j_mean_corr[xx,i] = J_mean
@@ -691,7 +699,8 @@ def Calc(Ite_pop, Abs_ite,
 #            l_ap[l_ap<0]=0
 #            l_ap[l_ap>1]=1
             if (l_ap>1) or (l_ap<0):
-                print(l_ap, i, lambda_approx_in[xx, i, :, :].min(),lambda_approx_out[xx, i, :, :].min())
+                logger.info(l_ap, i, lambda_approx_in[xx, i, :, :].min(),
+                  lambda_approx_out[xx, i, :, :].min())
             B_int[B_place == xx] = J_mean*1.
             if Alt_ref[i] == 0:
                 Fre_weight = trapz_inte_edge(F_vl_i[xx][i], Fre_range_i[xx])
@@ -752,7 +761,7 @@ def Calc(Ite_pop, Abs_ite,
         elif i == Alt_ref.size-1:
             n_new = np.linalg.inv(A_m).dot(b)
         else:
-            print('check alt. grid', i, Alt_ref[i])
+            logger.info('check alt. grid', i, Alt_ref[i])
         n_delta = n_new-n_old
         if update_population is True:
             new_pop[i, 0, :] = n_new

--- a/typhon/physics/units/em.py
+++ b/typhon/physics/units/em.py
@@ -32,6 +32,9 @@ from typhon.physics.units.common import (ureg, radiance_units)
 from typhon.physics.units.tools import UnitsAwareDataArray as UADA
 
 
+logger = logging.getLogger(__name__)
+
+
 __all__ = [
     'FwmuMixin',
     'SRF',
@@ -525,12 +528,12 @@ def specrad_frequency_to_planck_bt(L, f):
     # f needs to be double to prevent overflow
     f = numpy.asarray(f).astype(numpy.float64)
     if L.size > 1500000:
-        logging.debug("Doing actual BT conversion: {:,} spectra * {:,} "
-                      "frequencies = {:,} radiances".format(
-                          L.size // L.shape[-1], f.size, L.size))
+        logger.debug("Doing actual BT conversion: {:,} spectra * {:,} "
+                     "frequencies = {:,} radiances".format(
+                         L.size // L.shape[-1], f.size, L.size))
     # BT = (h * f) / (k * numpy.log((2*h*f**3)/(L * c**2) + 1))
     BT = numexpr.evaluate("(h * f) / (k * log((2*h*f**3)/(L * c**2) + 1))")
     BT = numpy.ma.masked_invalid(BT)
     if L.size > 1500000:
-        logging.debug("(done)")
+        logger.debug("(done)")
     return ureg.Quantity(BT, ureg.K)

--- a/typhon/retrieval/mcmc/mcmc.py
+++ b/typhon/retrieval/mcmc/mcmc.py
@@ -11,7 +11,12 @@ References
 [1] Andrew Gelman et al., Bayesian Data Analysis, 3rd Edition
 
 """
+import logging
+
 import numpy as np
+
+
+logger = logging.getLogger(__name__)
 
 
 def r_factor(stats):
@@ -238,7 +243,7 @@ class MCMC:
         else:
             ar = 0.0
 
-        print("MCMC Step " + str(step) + ": " + "ar = " + str(ar))
+        logger.info("MCMC Step " + str(step) + ": " + "ar = " + str(ar))
 
     def warm_up(self, ws, x0s, n_steps):
         """

--- a/typhon/retrieval/qrnn/qrnn.py
+++ b/typhon/retrieval/qrnn/qrnn.py
@@ -1,8 +1,10 @@
-import numpy as np
-from scipy.interpolate import CubicSpline
 import copy
+import logging
 import os
 import pickle
+
+import numpy as np
+from scipy.interpolate import CubicSpline
 
 # Keras Imports
 try:
@@ -20,6 +22,9 @@ except ImportError:
 ################################################################################
 
 import keras.backend as K
+
+
+logger = logging.getLogger(__name__)
 
 
 def skewed_absolute_error(y_true, y_pred, tau):
@@ -107,7 +112,7 @@ class TrainingGenerator:
         self.i = 0
 
     def __iter__(self):
-        print("iter...")
+        logger.info("iter...")
         return self
 
     def __next__(self):
@@ -176,7 +181,7 @@ class AdversarialTrainingGenerator:
         self.eps = eps
 
     def __iter__(self):
-        print("iter...")
+        logger.info("iter...")
         return self
 
     def __next__(self):
@@ -294,7 +299,7 @@ class LRDecay(keras.callbacks.Callback):
             keras.backend.set_value(
                 self.model.optimizer.lr, lr / self.lr_decay)
             self.steps = 0
-            print("\n Reduced learning rate to " + str(lr))
+            logger.info("\n Reduced learning rate to " + str(lr))
 
             if lr < self.lr_minimum:
                 self.model.stop_training = True
@@ -527,11 +532,11 @@ class QRNN:
                 loss = self.models[0].evaluate(
                     (x_test_fold - self.x_mean) / self.x_sigma,
                     y_test_fold)
-                print(loss)
+                logger.info(loss)
                 results += [loss]
-        print(results)
+        logger.info(results)
         results = np.array(results)
-        print(results)
+        logger.info(results)
         return (np.mean(results, axis=0), np.std(results, axis=0))
 
     def fit(self,
@@ -827,7 +832,7 @@ class QRNN:
             y_t[-1] = 1.0
 
         else:
-            print(y)
+            logger.info(y)
             x_new = np.zeros(x.size - 1)
             x_new[2:-2] = 0.5 * (x[2:-3] + x[3:-2])
             x_new[0:2] = x[0:2]

--- a/typhon/retrieval/spareice/common.py
+++ b/typhon/retrieval/spareice/common.py
@@ -79,9 +79,6 @@ import xarray as xr
 
 from ..common import RetrievalProduct
 
-# Use the typhon style for all plots:
-plt.style.use(styles('typhon'))
-
 __all__ = [
     'SPAREICE',
 ]

--- a/typhon/retrieval/spareice/common.py
+++ b/typhon/retrieval/spareice/common.py
@@ -55,6 +55,7 @@ Examples:
 """
 from ast import literal_eval
 import itertools
+import logging
 import os
 from os.path import join, dirname
 import warnings
@@ -86,6 +87,9 @@ __all__ = [
 # The path to the standard weights:
 PARAMETERS_DIR = join(dirname(__file__), 'parameters')
 STANDARD_FILE = join(PARAMETERS_DIR, "standard.json")
+
+
+logger = logging.getLogger(__name__)
 
 
 class SPAREICE:
@@ -121,7 +125,7 @@ class SPAREICE:
         retrieved = spareice.retrieve(standardized_data)
     """
 
-    def __init__(self, file=None, collocator=None, processes=10, verbose=2,
+    def __init__(self, file=None, collocator=None, processes=10, verbose=0,
                  sea_mask_file=None, elevation_file=None):
         """Initialize a SPAREICE object
 
@@ -134,8 +138,8 @@ class SPAREICE:
             processes: Number of processes to parallelize the training or
                 collocation search. 10 is the default. Best value depends on
                 your machine.
-            verbose: An integer value. The higher the value, the more debug
-                messages are printed.
+            verbose (int): Control ``GridSearchCV`` verbosity. The higher the
+            value, the more debug messages are printed.
         """
 
         self.verbose = verbose
@@ -158,7 +162,7 @@ class SPAREICE:
             self.elevation_grid = ds.data.squeeze().values
 
         if collocator is None:
-            self.collocator = Collocator(verbose=verbose)
+            self.collocator = Collocator()
         else:
             self.collocator = collocator
 
@@ -184,12 +188,10 @@ class SPAREICE:
             self.load(file)
 
     def _debug(self, msg):
-        if self.verbose > 1:
-            print(f"[{self.name}] {msg}")
+        logger.debug(f"[{self.name}] {msg}")
 
     def _info(self, msg):
-        if self.verbose > 0:
-            print(f"[{self.name}] {msg}")
+        logger.info(f"[{self.name}] {msg}")
 
     def _iwp_model(self, processes, cv_folds):
         """Return the default model for the IWP regressor
@@ -610,7 +612,7 @@ class SPAREICE:
                 "You need to pass a Collocations object or a list with a MHS "
                 "and AVHRR fileset!"
             )
-        print(f"Took {timer} hours to retrieve SPARE-ICE")
+        logger.info(f"Took {timer} hours to retrieve SPARE-ICE")
 
     def score(self, data):
         """Calculate the score of SPARE-ICE on testing data
@@ -703,13 +705,13 @@ class SPAREICE:
         if not hasattr(trainer, "cv_results_"):
             return
 
-        print("Best parameters found on training dataset:\n",
+        logger.info("Best parameters found on training dataset:\n",
               trainer.best_params_)
 
         means = trainer.cv_results_['mean_test_score']
         stds = trainer.cv_results_['std_test_score']
         for mean, std, params in zip(means, stds, trainer.cv_results_['params']):  # noqa
-            print("%0.3f (+/-%0.03f) for %r" % (mean, std * 2, params))
+            logger.info("%0.3f (+/-%0.03f) for %r" % (mean, std * 2, params))
 
     def report(self, output_dir, experiment, data):
         """Test the performance of SPARE-ICE and plot it

--- a/typhon/tests/arts/xml/test_matpack_types.py
+++ b/typhon/tests/arts/xml/test_matpack_types.py
@@ -226,7 +226,6 @@ class TestSave:
     def test_save_empty_vector(self):
         """Save empty Vector to file, read it and compare the results."""
         reference = _create_empty_tensor(1)
-        print(reference)
         xml.save(reference, self.f)
         test_data = xml.load(self.f)
         assert np.array_equal(test_data, reference)
@@ -234,7 +233,6 @@ class TestSave:
     def test_save_empty_matrix(self):
         """Save empty Matrix to file, read it and compare the results."""
         reference = _create_empty_tensor(2)
-        print(reference)
         xml.save(reference, self.f)
         test_data = xml.load(self.f)
         assert np.array_equal(test_data, reference)

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -119,8 +119,6 @@ class TestFileSet:
             placeholder={"satellite": 'SatelliteA'},
         )
 
-        self._print_files(list(files))
-
         # Sort this after paths rather than times (because the times are all
         # equal)
         check = list(sorted([
@@ -211,8 +209,6 @@ class TestFileSet:
         filesets = self.init_filesets()
         filters = {"satellite": "SatelliteB"}
         result = filesets["tutorial"]["2018-01-01 03:00", filters]
-
-        print(repr(result["time"].astype("M8[s]")))
 
         check = np.array(
             ['2018-01-01T00:00:00.000000000', '2018-01-01T00:20:00.000000000',
@@ -704,19 +700,6 @@ class TestFileSet:
 
         assert a_reference == a_retrieved
         assert b_reference == b_retrieved
-
-    def _print_files(self, files, comma=False):
-        print("[")
-        for file in files:
-            if isinstance(file, FileInfo):
-                print(self._repr_file_info(file))
-            else:
-                self._print_files(file, True)
-
-        if comma:
-            print("],")
-        else:
-            print("]")
 
     def _repr_file_info(self, file_info):
 


### PR DESCRIPTION
This PR:
* Introduces the usage of the ``logging`` standard module
* Adds a top-level convenience function ``typhon.set_loglevel()`` to control the logging level
* Replaces (almost) all calls of the ``print()`` function with the appropriate ``logging`` function
* Add information for developers on how to create log messages

In general, Typhon should not print any messages to ``stdout`` by default. To restore output, you can set the logging level by using the standard module
```python
logging.basicConfig(logging.INFO)
```
or the Typhon convenience function
```python
typhon.set_loglevel(logging.INFO)
```

Cheers,
Lukas

---
In addition:
* remove an outdated backup file 
* fix a bug in the ``DopplerWind`` class (switch between 'red' and 'blue' shift did not work)