### PR TITLE
Fixing a typo in the example

### DIFF
--- a/doc/faq/atm_fields_compact_construction.rst
+++ b/doc/faq/atm_fields_compact_construction.rst
@@ -53,4 +53,4 @@ The following code snippet demonstrates how to create an
     atm_fields_compact.check_dimension()
 
     # Write the atm_fields_compact to an XML file that can be read by ARTS.
-    typhon.arts.xml.save(atm_fields_comapct, 'atmfield.xml')
+    typhon.arts.xml.save(atm_fields_compact, 'atmfield.xml')


### PR DESCRIPTION
The portion of the code did not run properly because of a misspelling in a variable name.