### PR TITLE
Adjust background color of dark stylesheet

### DIFF
--- a/typhon/plots/stylelib/typhon-dark.mplstyle
+++ b/typhon/plots/stylelib/typhon-dark.mplstyle
@@ -5,7 +5,7 @@ patch.edgecolor: white
 
 text.color: white
 
-axes.facecolor: 333333
+axes.facecolor: 16161d
 axes.edgecolor: white
 axes.labelcolor: white
 axes.prop_cycle: cycler('color', ['ff8a80', '82b1ff', 'b9f6ca', 'ea80fc', 'ffd180', 'ff80ab', '84ffff', 'f4ff81'])
@@ -15,8 +15,8 @@ ytick.color: white
 
 grid.color: grey
 
-figure.facecolor: 333333
-figure.edgecolor: 333333
+figure.facecolor: 16161d
+figure.edgecolor: 16161d
 
-savefig.facecolor: 333333
-savefig.edgecolor: 333333
+savefig.facecolor: 16161d
+savefig.edgecolor: 16161d


### PR DESCRIPTION
The background color is darkened to increase the contrast in general.

Old:
![typhon-dark-old](https://user-images.githubusercontent.com/9482218/71179992-92564e80-2271-11ea-9954-f3d339efb977.png)

New:
![typhon-dark-new](https://user-images.githubusercontent.com/9482218/71179997-94b8a880-2271-11ea-96b3-43742cc19358.png)