### PR TITLE
Revise typhon stylesheet

### DIFF
--- a/typhon/plots/stylelib/typhon-constrained.mplstyle
+++ b/typhon/plots/stylelib/typhon-constrained.mplstyle
@@ -1,0 +1,2 @@
+## Figure layout
+figure.constrained_layout.use: True

--- a/typhon/plots/stylelib/typhon-tight.mplstyle
+++ b/typhon/plots/stylelib/typhon-tight.mplstyle
@@ -1,0 +1,2 @@
+## Figure layout
+figure.autolayout : True

--- a/typhon/plots/stylelib/typhon.mplstyle
+++ b/typhon/plots/stylelib/typhon.mplstyle
@@ -48,5 +48,5 @@ legend.fontsize : small
 
 ### FIGURE
 # See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
-figure.figsize : 10, 6.1803398874989481 # figure size in inches
+figure.figsize : 10, 6.18 # figure size in inches
 figure.titlesize : large # same as axes.titlesize

--- a/typhon/plots/stylelib/typhon.mplstyle
+++ b/typhon/plots/stylelib/typhon.mplstyle
@@ -50,3 +50,6 @@ legend.fontsize : small
 # See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
 figure.figsize : 10, 6.18 # figure size in inches
 figure.titlesize : large # same as axes.titlesize
+
+### SAVING FIGURES
+savefig.dpi: 144  # dots per inches

--- a/typhon/plots/stylelib/typhon.mplstyle
+++ b/typhon/plots/stylelib/typhon.mplstyle
@@ -50,10 +50,3 @@ legend.fontsize : small
 # See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
 figure.figsize : 10, 6.1803398874989481 # figure size in inches
 figure.titlesize : large # same as axes.titlesize
-
-### SAVING FIGURES
-savefig.bbox : tight # 'tight' or 'standard'.
-                     # 'tight' is incompatible with pipe-based animation
-                     # backends but will workd with temporary file based ones:
-                     # e.g. setting animation.writer to ffmpeg will not work,
-                     # use ffmpeg_file instead


### PR DESCRIPTION
This PR revises the stylesheet for matplotlib:
* Do not use the tight bounding box when saving figures
* Increase the default DPI size to 144

**Warning:** The switch to the standard bounding box will change the appearance of your plots. To restore the old behaviour set:
```python
plt.savefig("test.pdf", bbox_inches="tight")
```

We decided to no longer modify the bounding box as this makes the final image resolution unpredictable. If you want to get rid off white space around your plots, you should use functions to modify the plot layout within your figure ([constrained layout](https://matplotlib.org/tutorials/intermediate/constrainedlayout_guide.html) or [tight layout](https://matplotlib.org/tutorials/intermediate/tight_layout_guide.html)). I added two convenient stylesheets to enable either of them:
```python
typhon.plots.styles.use(["typhon", "typhon-tight"])
# or
typhon.plots.styles.use(["typhon", "typhon-constrained"])
```