### PR TITLE
Remove space in __name__ attribute of custom loss function to make it…

### DIFF
--- a/typhon/retrieval/qrnn/qrnn.py
+++ b/typhon/retrieval/qrnn/qrnn.py
@@ -67,7 +67,7 @@ class QuantileLoss:
     """
 
     def __init__(self, quantiles):
-        self.__name__ = "Quantile Loss"
+        self.__name__ = "QuantileLoss"
         self.quantiles = quantiles
 
     def __call__(self, y_true, y_pred):


### PR DESCRIPTION
… compatible with newer TF versions.