### PR TITLE
Add utility to write figure to multiple files

### DIFF
--- a/typhon/plots/common.py
+++ b/typhon/plots/common.py
@@ -2,10 +2,14 @@
 
 """Utility functions related to plotting.
 """
+
+import pathlib
+import lzma
 import glob
 import itertools
 import os
 import string
+import pickle
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -321,3 +325,42 @@ def sorted_legend_handles_labels(ax=None, key=None, reverse=True):
                           ax.get_legend_handles_labels()[0]],
                          *ax.get_legend_handles_labels()),
                      reverse=reverse)))
+
+
+def write_multi(fig, name, exts=["png", "pdf", "pkz"]):
+    """Write figure to multiple files
+
+    Writes a matplotlib Figure object to multiple files.  By default, it
+    writes:
+
+        * png
+        * pdf
+        * pkz, pickle containing the figure object
+
+    but this can be configured by passing the ``exts`` argument.  Most will
+    be passed directly to ``print_figure``, except ``pkz``, which will use
+    ``pickle.dump``.
+
+    Still planned are special cases for ``info``, which will dump stack
+    information, and "tikz", which will use matplotlib2tikz to write a file
+    for use with the LaTeX pgfplots library.
+
+    Args:
+        fig (matplotlib.Figure)
+            Figure that is to be written to files.
+
+        name (str or pathlib.Path)
+            Name of destination, suffices will be added
+
+        exts (List[str], optional)
+            Extensions to write.
+    """
+
+    p = pathlib.Path(name)
+    for ext in exts:
+        of = p.with_suffix("." + ext)
+        if ext == "pkz":
+            with lzma.open(of, "wb") as fp:
+                pickle.dump(fig, fp, protocol=4)
+        else:
+            fig.canvas.print_figure(of)

--- a/typhon/plots/common.py
+++ b/typhon/plots/common.py
@@ -10,11 +10,13 @@ import itertools
 import os
 import string
 import pickle
+import logging
 
 import matplotlib.pyplot as plt
 import numpy as np
 from typhon import constants
 
+LOG = logging.getLogger(__name__)
 
 __all__ = [
     'center_colorbar',
@@ -359,6 +361,7 @@ def write_multi(fig, name, exts=["png", "pdf", "pkz"]):
     p = pathlib.Path(name)
     for ext in exts:
         of = p.with_suffix("." + ext)
+        LOG.debug(f"Writing to {of!s}")
         if ext == "pkz":
             with lzma.open(of, "wb") as fp:
                 pickle.dump(fig, fp, protocol=4)

--- a/typhon/plots/common.py
+++ b/typhon/plots/common.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from typhon import constants
 
-LOG = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = [
     'center_colorbar',
@@ -343,10 +343,6 @@ def write_multi(fig, name, exts=["png", "pdf", "pkz"]):
     be passed directly to ``print_figure``, except ``pkz``, which will use
     ``pickle.dump``.
 
-    Still planned are special cases for ``info``, which will dump stack
-    information, and "tikz", which will use matplotlib2tikz to write a file
-    for use with the LaTeX pgfplots library.
-
     Args:
         fig (matplotlib.Figure)
             Figure that is to be written to files.
@@ -358,10 +354,14 @@ def write_multi(fig, name, exts=["png", "pdf", "pkz"]):
             Extensions to write.
     """
 
+    # Still planned are special cases for ``info``, which will dump stack
+    # information, and "tikz", which will use matplotlib2tikz to write a file
+    # for use with the LaTeX pgfplots library.
+
     p = pathlib.Path(name)
     for ext in exts:
         of = p.with_suffix("." + ext)
-        LOG.debug(f"Writing to {of!s}")
+        logger.debug(f"Writing to {of!s}")
         if ext == "pkz":
             with lzma.open(of, "wb") as fp:
                 pickle.dump(fig, fp, protocol=4)

--- a/typhon/tests/plots/test_plots.py
+++ b/typhon/tests/plots/test_plots.py
@@ -3,6 +3,7 @@
 """
 import os
 import pathlib
+import logging
 
 import pytest
 
@@ -46,8 +47,9 @@ class TestPlots:
 
     @mock.patch("lzma.open", autospec=True)
     @mock.patch("pickle.dump", autospec=True)
-    def test_write_multi(self, pd, lo):
+    def test_write_multi(self, pd, lo, caplog):
         fig = mock.MagicMock()
+        caplog.set_level(logging.DEBUG)
         plots.common.write_multi(fig, "/tmp/nothing")
         fig.canvas.print_figure.assert_any_call(
                 pathlib.Path("/tmp/nothing.png"))
@@ -57,3 +59,6 @@ class TestPlots:
         lo.assert_called_once_with(
                 pathlib.Path("/tmp/nothing.pkz"), "wb")
         pd.assert_called_once()
+        assert "Writing to /tmp/nothing.pdf" in caplog.text
+        assert "Writing to /tmp/nothing.png" in caplog.text
+        assert "Writing to /tmp/nothing.pkz" in caplog.text

--- a/typhon/tests/plots/test_plots.py
+++ b/typhon/tests/plots/test_plots.py
@@ -59,6 +59,6 @@ class TestPlots:
         lo.assert_called_once_with(
                 pathlib.Path("/tmp/nothing.pkz"), "wb")
         pd.assert_called_once()
-        assert "Writing to /tmp/nothing.pdf" in caplog.text
-        assert "Writing to /tmp/nothing.png" in caplog.text
-        assert "Writing to /tmp/nothing.pkz" in caplog.text
+        assert "nothing.pdf" in caplog.text
+        assert "nothing.png" in caplog.text
+        assert "nothing.pkz" in caplog.text

--- a/typhon/tests/plots/test_plots.py
+++ b/typhon/tests/plots/test_plots.py
@@ -2,8 +2,11 @@
 """Testing the functions in typhon.plots.
 """
 import os
+import pathlib
 
 import pytest
+
+from unittest import mock
 
 from typhon import plots
 
@@ -40,3 +43,17 @@ class TestPlots:
         assert isinstance(style_paths, list)
         assert len(style_paths) > 0
         assert all(os.path.isfile(plots.styles(s)) for s in style_paths)
+
+    @mock.patch("lzma.open", autospec=True)
+    @mock.patch("pickle.dump", autospec=True)
+    def test_write_multi(self, pd, lo):
+        fig = mock.MagicMock()
+        plots.common.write_multi(fig, "/tmp/nothing")
+        fig.canvas.print_figure.assert_any_call(
+                pathlib.Path("/tmp/nothing.png"))
+        fig.canvas.print_figure.assert_any_call(
+                pathlib.Path("/tmp/nothing.pdf"))
+        assert fig.canvas.print_figure.call_count == 2
+        lo.assert_called_once_with(
+                pathlib.Path("/tmp/nothing.pkz"), "wb")
+        pd.assert_called_once()


### PR DESCRIPTION
Added a utility to `plots.common` that will write/print a figure to
multiple files, such as pdf, png, and pickle.