### PR TITLE
Fix for backwards incompatible change in AST library

### DIFF
--- a/typhon/arts/workspace/workspace.py
+++ b/typhon/arts/workspace/workspace.py
@@ -11,6 +11,7 @@ Attributes:
 """
 import ctypes as c
 import logging
+import sys
 import numpy  as np
 
 import ast
@@ -126,7 +127,11 @@ def arts_agenda(func):
         Helper function that creates a wrapper function around
         python code to be executed withing an ARTS agenda.
         """
-        m = Module(body)
+        if sys.version_info >= (3, 8):
+            # https://bugs.python.org/issue35894#msg334808
+            m = Module(body, [])
+        else:
+            m = Module(body)
 
         def callback(ptr):
             try:

--- a/typhon/arts/workspace/workspace.py
+++ b/typhon/arts/workspace/workspace.py
@@ -12,25 +12,19 @@ Attributes:
 import ctypes as c
 import logging
 import sys
-import numpy  as np
 
-import ast
-from   ast      import iter_child_nodes, parse, NodeVisitor, Call, Attribute, Name, \
-                       Expression, Expr, FunctionDef, Starred, Module, expr
+from   ast      import parse, Call, Name, Expression, Expr, FunctionDef, Starred, Module
 from   inspect  import getsource, getclosurevars
-from contextlib import contextmanager
 from copy       import copy
-from functools  import wraps
 import os
 
 from typhon.arts.workspace.api       import arts_api, VariableValueStruct, \
                                             data_path_push, data_path_pop, \
                                             include_path_push, include_path_pop
-from typhon.arts.workspace.methods   import WorkspaceMethod, workspace_methods
+from typhon.arts.workspace.methods   import workspace_methods
 from typhon.arts.workspace.variables import WorkspaceVariable, group_names, group_ids, \
                                             workspace_variables
 from typhon.arts.workspace.agendas   import Agenda
-from typhon.arts.workspace import variables as V
 from typhon.arts.workspace.output import CoutCapture
 from typhon.arts.workspace.utility import unindent
 

--- a/typhon/arts/workspace/workspace.py
+++ b/typhon/arts/workspace/workspace.py
@@ -13,18 +13,27 @@ import ctypes as c
 import logging
 import sys
 
-from   ast      import parse, Call, Name, Expression, Expr, FunctionDef, Starred, Module
-from   inspect  import getsource, getclosurevars
-from copy       import copy
+from ast import parse, Call, Name, Expression, Expr, FunctionDef, Starred, Module
+from inspect import getsource, getclosurevars
+from copy import copy
 import os
 
-from typhon.arts.workspace.api       import arts_api, VariableValueStruct, \
-                                            data_path_push, data_path_pop, \
-                                            include_path_push, include_path_pop
-from typhon.arts.workspace.methods   import workspace_methods
-from typhon.arts.workspace.variables import WorkspaceVariable, group_names, group_ids, \
-                                            workspace_variables
-from typhon.arts.workspace.agendas   import Agenda
+from typhon.arts.workspace.api import (
+    arts_api,
+    VariableValueStruct,
+    data_path_push,
+    data_path_pop,
+    include_path_push,
+    include_path_pop,
+)
+from typhon.arts.workspace.methods import workspace_methods
+from typhon.arts.workspace.variables import (
+    WorkspaceVariable,
+    group_names,
+    group_ids,
+    workspace_variables,
+)
+from typhon.arts.workspace.agendas import Agenda
 from typhon.arts.workspace.output import CoutCapture
 from typhon.arts.workspace.utility import unindent
 


### PR DESCRIPTION
This PR fixes a backwards incompatible change to the `ast.Module` class that has been introduced in Python 3.8