### PR TITLE
import from collections.abc rather than collections

### DIFF
--- a/typhon/trees.py
+++ b/typhon/trees.py
@@ -5,7 +5,7 @@ Trees are powerful structures to sort a huge amount of data and to speed up
 performing query requests on them significantly.
 """
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import pandas as pd
 import numba


### PR DESCRIPTION
Import `Iterable` from collections.abc rather than from collections.
Importing directly from collections is deprecated since Python 3.3
and will stop working in 3.9.