### PR TITLE
Fix import for in source tree build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,12 +16,12 @@
 import sys
 import os
 
-from typhon.environment import environ
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
+
+from typhon.environment import environ
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
Module was imported before path adjustment. Led to error when trying to
build the docs if typhon is not yet installed.