### PR TITLE
Partial support for filesystems in FileSet

### DIFF
--- a/doc/tutorials/fileset.rst
+++ b/doc/tutorials/fileset.rst
@@ -587,6 +587,31 @@ for-loop or simply :meth:`~typhon.files.fileset.FileSet.collect` alone:
    # Read the second line of all files at once:
    data_list = our_dataset.collect(read_args={"lineno": 2})
 
+Handling remote files
++++++++++++++++++++++
+
+The FileSet class works not only for files on your local file system,
+but also for remote filesystems such as Amazon S3, or files in an
+archive such as a zip file.  Please note that this functionality is still
+experimental and most FileHandlers only support local reading and writing,
+so functionality is currently limited to searching for files.
+
+.. code-block:: python
+
+	import s3fs
+	from typhon.files.fileset import FileSet
+	abi_fileset = FileSet(
+			path="noaa-goes16/ABI-L1b-RadF/{year}/{doy}/{hour}/OR_ABI-L1b-RadF-M6C*_G16_s{year}{doy}{hour}{minute}{second}*_e{end_year}{end_doy}{end_hour}{end_minute}{end_second}*_c*.nc",        name="abi",
+			fs=s3fs.S3FileSystem(anon=True))
+	for f in abi_fileset.find("2019-11-18T05:30", "2019-11-18T07:00"):
+		print(f)
+
+This will return all full-disk ABI L1B granules between the indicated
+times, for all channels.  The resulting files can then be downloaded or
+read using the s3 interface or directly with typhon if a FileHandler is
+file system aware (not implemented yet).  Note that unlike searching on
+a local file system, one should not include a leading / with the search
+path when searching on an s3 file system.
 
 Get information from a file
 ===========================

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ dependencies:
         - python>=3.6
         - cartopy
         - cython
+        - fsspec
         - gdal
         - keras
         - matplotlib>=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cartopy
 cython
+fsspec
 gdal
 keras
 matplotlib>=1.4

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "docutils",
+        "fsspec",
         "imageio",
         "matplotlib>=1.4",
         "netCDF4>=1.1.1",

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -2403,8 +2403,9 @@ class FileSet:
         if self.has_root:
             # We need the absolute path if it exists:
             # (but still with normal path separators)
-            # even on windows posixpath.abspath will give \\ !
-            return posixpath.abspath(self._path).replace(os.sep, "/")
+            # can't use posixpath.abspath, that (1) won't recognise c: as
+            # absolute and (2) still keep \\, so explicitly replace instead
+            return os.path.abspath(self._path).replace(os.sep, "/")
         else:
             # Or we don't, because on other file systems, such as s3fs or zip,
             # there are no absolute paths

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -1283,7 +1283,7 @@ class FileSet:
         for new_dir in self.file_system.glob(os.path.join(base_dir + "*", "")):
             # some/all (?) file_system implementations do not end directories
             # in a /, glob.glob does
-            if not new_dir.endswith("/") and self.file_system.isdir(new_dir):
+            if not (new_dir.endswith(os.sep) or new_dir.endswith("/")) and self.file_system.isdir(new_dir):
                 new_dir += os.sep
             # The glob function yields full paths, but we want only to check
             # the new pattern that was added:

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -2582,6 +2582,11 @@ class FileSet:
 
         # Mask all dots and convert the asterisk to regular expression syntax:
         path = path.replace("\\", "\\\\").replace(".", r"\.").replace("*", ".*?")
+        # due to support for external file systems, file separators could be
+        # either local (os.sep) or forward / (always on s3fs, ftp, elsewhere).
+        # Therefore, let's make \ also match / on Windows.
+        if os.sep != "/":
+            path = path.replace("\\\\", "[\\\\/]")
 
         # Python's standard regex module (re) cannot handle multiple groups
         # with the same name. Hence, we need to cover duplicated placeholders

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -1287,10 +1287,10 @@ class FileSet:
             # some/all (?) file_system implementations do not end directories
             # in a /, glob.glob does
             if not (new_dir.endswith(os.sep) or new_dir.endswith("/")) and self.file_system.isdir(new_dir):
-                new_dir += os.sep
+                new_dir += "/"  # always / with AbstractFileSystem, not os.sep
             # The glob function yields full paths, but we want only to check
             # the new pattern that was added:
-            basename = new_dir[len(base_dir):].rstrip(os.sep)
+            basename = new_dir[len(base_dir):].rstrip(os.sep + "/")
             try:
                 new_attr = {
                     **dir_attr,

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -2403,7 +2403,8 @@ class FileSet:
         if self.has_root:
             # We need the absolute path if it exists:
             # (but still with normal path separators)
-            return posixpath.abspath(self._path)
+            # even on windows posixpath.abspath will give \\ !
+            return posixpath.abspath(self._path).replace(os.sep, "/")
         else:
             # Or we don't, because on other file systems, such as s3fs or zip,
             # there are no absolute paths

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -434,7 +434,7 @@ class FileSet:
 
         # Filesystem support for searching remotely or in archives
         self.file_system = fs or LocalFileSystem()
-        self.has_root = self.file_system.exists(os.sep)
+        self.has_root = isinstance(self.file_system, LocalFileSystem)
 
         # The path parameters (will be set and documented in the path setter
         # method):

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -14,6 +14,7 @@ import json
 import logging
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 import os.path
+import posixpath
 import re
 import shutil
 from sys import platform
@@ -1250,8 +1251,10 @@ class FileSet:
                        if ch in self._special_chars):
                 # We can add this sub directory part because it will always
                 # match to our path
+                # NB: using posixpath rather than os.path because
+                # AbstractFileSystem objects always work with / not \
                 search_dirs = [
-                    (os.path.join(old_dir, subdir_chunk), attr)
+                    (posixpath.join(old_dir, subdir_chunk), attr)
                     for old_dir, attr in search_dirs
                 ]
                 continue
@@ -1280,7 +1283,7 @@ class FileSet:
 
     def _get_matching_dirs(self, dir_with_attrs, regex):
         base_dir, dir_attr = dir_with_attrs
-        for new_dir in self.file_system.glob(os.path.join(base_dir + "*", "")):
+        for new_dir in self.file_system.glob(posixpath.join(base_dir + "*", "")):
             # some/all (?) file_system implementations do not end directories
             # in a /, glob.glob does
             if not (new_dir.endswith(os.sep) or new_dir.endswith("/")) and self.file_system.isdir(new_dir):
@@ -1325,7 +1328,7 @@ class FileSet:
             A FileInfo object with the file path and time coverage
         """
 
-        for filename in self.file_system.glob(os.path.join(path, "*")):
+        for filename in self.file_system.glob(posixpath.join(path, "*")):
             if regex.match(filename):
                 file_info = self.get_info(
                         FileInfo(filename, fs=self.file_system))

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -1731,7 +1731,7 @@ class FileSet:
 
     def make_dirs(self, filename):
         self.file_system.makedirs(
-            os.path.dirname(filename),
+            posixpath.dirname(filename),
             exist_ok=True
         )
 
@@ -2270,7 +2270,7 @@ class FileSet:
         else:
             # Create the new directory if necessary.
             self.file_system.makedirs(
-                    os.path.dirname(new_filename), exist_ok=True)
+                    posixpath.dirname(new_filename), exist_ok=True)
 
             if copy:
                 self.file_system.copy(file_info.path, new_filename)
@@ -2402,7 +2402,8 @@ class FileSet:
 
         if self.has_root:
             # We need the absolute path if it exists:
-            return os.path.abspath(self._path)
+            # (but still with normal path separators)
+            return posixpath.abspath(self._path)
         else:
             # Or we don't, because on other file systems, such as s3fs or zip,
             # there are no absolute paths
@@ -2419,7 +2420,7 @@ class FileSet:
         # directory and the filename. The sub directory and filename may
         # contain regex/placeholder, the base directory not. We need to split
         # the path into these three parts to enable file finding.
-        directory = os.path.dirname(self.path)
+        directory = posixpath.dirname(self.path)
         index_of_sub_directory = \
             next(
                 (i for i, ch in enumerate(directory)

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -5,11 +5,10 @@ Created by John Mrziglod, June 2017
 """
 
 import atexit
-from collections import Counter, defaultdict, deque, OrderedDict
+from collections import Counter, deque, OrderedDict
 from copy import deepcopy
 from datetime import datetime, timedelta
 import gc
-import glob
 from itertools import tee
 import json
 import logging
@@ -18,10 +17,8 @@ import os.path
 import re
 import shutil
 from sys import platform
-import threading
 import traceback
 import warnings
-import fsspec
 
 import numpy as np
 import pandas as pd
@@ -1725,8 +1722,8 @@ class FileSet:
                     self.info_cache.update(info_cache)
             except Exception as err:
                 warnings.warn(
-                    f"Could not load the file information from cache file "
-                    "'{filename}':\n{err}."
+                    "Could not load the file information from cache file "
+                    f"'{filename}':\n{err}."
                 )
 
     def make_dirs(self, filename):
@@ -2232,8 +2229,7 @@ class FileSet:
 
         return destination
 
-    @staticmethod
-    def _move_single_file(
+    def _move_single_file(self,
             file_info, fileset, destination, convert, copy):
         """This is a small wrapper function for moving files. It is better to
         use :meth:`FileSet.move` directly.

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -1286,7 +1286,7 @@ class FileSet:
             # some/all (?) file_system implementations do not end directories
             # in a /, glob.glob does
             if not new_dir.endswith("/") and self.file_system.isdir(new_dir):
-                new_dir += "/"
+                new_dir += os.sep
             # The glob function yields full paths, but we want only to check
             # the new pattern that was added:
             basename = new_dir[len(base_dir):].rstrip(os.sep)

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -1283,6 +1283,10 @@ class FileSet:
     def _get_matching_dirs(self, dir_with_attrs, regex):
         base_dir, dir_attr = dir_with_attrs
         for new_dir in self.file_system.glob(os.path.join(base_dir + "*", "")):
+            # some/all (?) file_system implementations do not end directories
+            # in a /, glob.glob does
+            if not new_dir.endswith("/") and self.file_system.isdir(new_dir):
+                new_dir += "/"
             # The glob function yields full paths, but we want only to check
             # the new pattern that was added:
             basename = new_dir[len(base_dir):].rstrip(os.sep)

--- a/typhon/files/fileset.py
+++ b/typhon/files/fileset.py
@@ -2436,7 +2436,8 @@ class FileSet:
             # Later, we iterate over all possible sub directories and find
             # those that match the regex / placeholders. Hence, we split the
             # sub directory into chunks for each hierarchy level:
-            self._sub_dir_chunks = self._sub_dir.split(os.path.sep)
+            # (with posixpath, because fsspec always uses this)
+            self._sub_dir_chunks = self._sub_dir.split(posixpath.sep)
 
             # The sub directory time resolution is needed for find_closest:
             self._sub_dir_time_resolution = self._get_time_resolution(

--- a/typhon/files/handlers/common.py
+++ b/typhon/files/handlers/common.py
@@ -258,7 +258,7 @@ class FileHandler:
     def _ensure_local_filesystem(self, file_info):
         if not isinstance(file_info.file_system, LocalFileSystem):
             raise NotImplementedError(
-                    f"File handler {str(type(self).__name__):s} can only "
+                    f"File handler {type(self).__name__:s} can only "
                     "read from local file system, not from "
                     f"{str(type(file_info.file_system).__name__)}")
 

--- a/typhon/files/handlers/common.py
+++ b/typhon/files/handlers/common.py
@@ -13,6 +13,8 @@ import pandas as pd
 import xarray as xr
 import numpy as np
 
+from fsspec.implementations.local import LocalFileSystem
+
 # The HDF4 file handler needs pyhdf, this might be very tricky to install if
 # you cannot use anaconda. Hence, I do not want it to be a hard dependency:
 pyhdf_is_installed = False
@@ -253,6 +255,12 @@ class FileHandler:
             "This file handler does not support writing data to a file. You "
             "should use a different file handler.")
 
+    def _ensure_local_filesystem(self, file_info):
+        if not isinstance(file_info.file_system, LocalFileSystem):
+            raise NotImplementedError(
+                    f"File handler {str(type(self).__name__):s} can only "
+                    "read from local file system, not from "
+                    f"{str(type(file_info.file_system).__name__)}")
 
 class FileInfo(os.PathLike):
     """Container of information about a file (time coverage, etc.)
@@ -283,7 +291,7 @@ class FileInfo(os.PathLike):
         file_info.times  # [datetime(2018, 1, 1), datetime(2018, 1, 10)]
         file_info.attr   # {}
     """
-    def __init__(self, path=None, times=None, attr=None):
+    def __init__(self, path=None, times=None, attr=None, fs=None):
         """Initialise a FileInfo object.
 
         Args:
@@ -291,6 +299,7 @@ class FileInfo(os.PathLike):
             times: A list or tuple of two datetime objects indicating start and
                 end time of the file.
             attr: A dictionary with further attributes.
+            fs: Implementation of fsspec file system
         """
         super(FileInfo, self).__init__()
 
@@ -304,6 +313,8 @@ class FileInfo(os.PathLike):
             self.attr = {}
         else:
             self.attr = attr
+
+        self.file_system = fs or LocalFileSystem()
 
     def __eq__(self, other):
         return self.path == other.path and self.times == other.times
@@ -319,7 +330,8 @@ class FileInfo(os.PathLike):
     def __repr__(self):
         return f"FileInfo(\n  '{self.path}',\n" \
                f"  times={self.times},\n" \
-               f"  attr={self.attr}\n)"
+               f"  attr={self.attr},\n" \
+               f"  fs={self.file_system})"
 
     def __str__(self):
         return self.path
@@ -427,7 +439,8 @@ class CSV(FileHandler):
             A xarray.Dataset object.
         """
 
-        data = pd.read_csv(file_info.path, **kwargs).to_xarray()
+        with file_info.file_system.open(file_info.path, "rt") as fp:
+            data = pd.read_csv(fp, **kwargs).to_xarray()
 
         if fields is None:
             return data
@@ -483,6 +496,7 @@ class HDF4(FileHandler):
             A xarray.Dataset object.
         """
 
+        self._ensure_local_filesystem(file_info)
         if fields is None:
             raise NotImplementedError(
                 "You have to set field names. Loading the complete file is not"
@@ -561,6 +575,7 @@ class HDF5(FileHandler):
             A xrarray.Dataset object.
         """
 
+        self._ensure_local_filesystem(file_info)
         # Here, the user fields overwrite the standard fields:
         if fields is None:
             raise NotImplementedError(
@@ -650,6 +665,7 @@ class NetCDF4(FileHandler):
                 data = fh.read("filename.nc", fields=["temp", "lat", "lon"])
 
         """
+        self._ensure_local_filesystem(file_info)
         # xr.open_dataset does still not support loading all groups from a
         # file except a very cumbersome (and expensive) way by using the
         # parameter `group`. To avoid this, we load all groups and their

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -46,7 +46,12 @@ class TestFileSet:
         # check if this filesystem returns absolute or relative and adapt
         # refdir accordingly
         try:
-            fn = fs.ls(self.refdir)[0]
+            cont = fs.ls(self.refdir)
+            # on windows, this appears empty (?!) if we have a zip and refdir
+            # contains a drive
+            if len(cont) == 0 and self.refdir[1] == ":":
+                return self.refdir[3:]
+            fn = cont[0]
             if fn[0] not in (os.sep, "/", self.refdir[0]):
                 return self.refdir[1:]
         except (IndexError, AttributeError, StopIteration, KeyError, TypeError):

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -1,5 +1,6 @@
 import os
-from os.path import dirname, join
+from os.path import dirname
+from posixpath import join  # LocalFileSystem always uses /
 
 import datetime
 import numpy as np

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -47,7 +47,7 @@ class TestFileSet:
             fn = fs.ls(self.refdir)[0]
             if fn[0] not in (os.sep, "/", self.refdir[0]):
                 return self.refdir[1:]
-        except (AttributeError, StopIteration, KeyError, TypeError):
+        except (IndexError, AttributeError, StopIteration, KeyError, TypeError):
             pass
         return self.refdir
 

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -59,9 +59,6 @@ class TestFileSet:
         return self.refdir
 
     def init_filesets(self, fs=None):
-#        if self.filesets is not None:
-#            return self.filesets
-
         self.filesets = FileSetManager()
 
         refdir = self._refdir_for_fs(fs)

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -15,7 +15,8 @@ class TestFileSet:
     """Testing the fileset methods."""
 
     filesets = None
-    refdir = get_testfiles_directory("filesets")
+    # replace separator, fsspec always uses forward /
+    refdir = get_testfiles_directory("filesets").replace(os.sep, "/")
 
     @pytest.fixture
     def file_system(self, request, tmp_path):

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -1,8 +1,10 @@
+import os
 from os.path import dirname, join
 
 import datetime
 import numpy as np
 import pytest
+import shutil
 
 from typhon.files import FileHandler, FileInfo, FileSet, FileSetManager
 from typhon.files.utils import get_testfiles_directory
@@ -14,25 +16,63 @@ class TestFileSet:
     filesets = None
     refdir = get_testfiles_directory("filesets")
 
-    def init_filesets(self):
-        if self.filesets is not None:
-            return self.filesets
+    @pytest.fixture
+    def file_system(self, request, tmp_path):
+        """Prepare filesystem.
+
+        Prepare a filesystem to test if the filesystem spec works with it.
+        """
+        if request.param == "zip":
+            from fsspec.implementations.zip import ZipFileSystem
+            from shutil import make_archive
+            # prepare archive to test on
+            archive = tmp_path / "test"
+            shutil.make_archive(
+                    archive, "zip", os.curdir, self.refdir)
+            return ZipFileSystem(archive.with_suffix(".zip"))
+        elif request.param == "local":
+            from fsspec.implementations.local import LocalFileSystem
+            return LocalFileSystem()
+
+    def _refdir_for_fs(self, fs):
+        """Get appropriate reference dir for fs.
+
+        Some fs, such as ZipFileSystem or S3FS, don't return leading /, then
+        our refdir shouldn't contain this either.
+        """
+
+        # check if this filesystem returns absolute or relative and adapt
+        # refdir accordingly
+        try:
+            fn = fs.ls(self.refdir)[0]
+            if fn[0] not in (os.sep, "/", self.refdir[0]):
+                return self.refdir[1:]
+        except (AttributeError, StopIteration, KeyError, TypeError):
+            pass
+        return self.refdir
+
+    def init_filesets(self, fs=None):
+#        if self.filesets is not None:
+#            return self.filesets
 
         self.filesets = FileSetManager()
 
+        refdir = self._refdir_for_fs(fs)
         self.filesets += FileSet(
             join(
-                self.refdir,
+                refdir,
                 "tutorial", "{satellite}", "{year}-{month}-{day}",
                 "{hour}{minute}{second}-{end_hour}{end_minute}{end_second}.nc"
             ),
             name="tutorial",
+            fs=fs
         )
 
         self.filesets += FileSet(
-            join(self.refdir, "single_file.nc",),
+            join(refdir, "single_file.nc",),
             name="single",
             time_coverage=["2018-01-01", "2018-01-03"],
+            fs=fs
         )
 
         def sequence_get_info(file_info, **kwargs):
@@ -49,16 +89,17 @@ class TestFileSet:
             return file_info
 
         self.filesets += FileSet(
-            join(self.refdir, "sequence",
+            join(refdir, "sequence",
                  "{year}", "{doy}", "sequence*.txt",),
             name="sequence-wildcard",
             handler=FileHandler(
                 info=sequence_get_info,
             ),
             info_via="handler",
+            fs=fs
         )
         self.filesets += FileSet(
-            join(self.refdir, "sequence",
+            join(refdir, "sequence",
                  "{year}", "{doy}", "sequence{id}.txt",
             ),
             handler=FileHandler(
@@ -66,16 +107,18 @@ class TestFileSet:
             ),
             name="sequence-placeholder",
             info_via="both",
-            placeholder={"id": r"\d{4}"}
+            placeholder={"id": r"\d{4}"},
+            fs=fs
         )
 
         self.filesets += FileSet(
-            join(self.refdir,
+            join(refdir,
                  # NSS.HIRX.NJ.D99127.S0632.E0820.B2241718.WI.gz
                  "regex", "NSS.HIR[XS].{satcode}.D{year2}{doy}.S{hour}"
                  "{minute}.E{end_hour}{end_minute}.B{B}.{station}.gz"
             ),
             name="regex-HIRS",
+            fs=fs
         )
         self.filesets["regex-HIRS"].set_placeholders(
             satcode=".{2}", B=r"\d{7}", station=".{2}",
@@ -84,13 +127,14 @@ class TestFileSet:
         return self.filesets
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_contains(self):
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_contains(self, file_system):
         """Test whether all filesets cover the testing timestamps.
 
         Returns:
             None
         """
-        filesets = self.init_filesets()
+        filesets = self.init_filesets(file_system)
         tests = [
             # [Timestamp(s), Should it be covered by the filesets?]
             ["2016-01-01", False],
@@ -110,86 +154,89 @@ class TestFileSet:
                 assert (timestamp in fileset) == check
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_glob(self):
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_glob(self, file_system):
+        refdir = self._refdir_for_fs(file_system)
         files = FileSet(
             join(
-                self.refdir,
+                refdir,
                 "tutorial", "{satellite}", "*", "*.nc"
             ),
             placeholder={"satellite": 'SatelliteA'},
+            fs=file_system
         )
 
         # Sort this after paths rather than times (because the times are all
         # equal)
         check = list(sorted([
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-02', '000000-040000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-02', '080000-120000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-02', '200000-000000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-02', '040000-080000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-02', '120000-160000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-02', '160000-200000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-01', '000000-040000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-01', '080000-120000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-01', '200000-000000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-01', '040000-080000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-01', '120000-160000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
                 {'satellite': 'SatelliteA'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteA', '2018-01-01', '160000-200000.nc'),
                 [datetime.datetime(1, 1, 1, 0, 0),
                  datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)],
@@ -200,13 +247,13 @@ class TestFileSet:
 
     @pytest.mark.skip
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_magic_methods(self):
+    def test_magic_methods(self, file_system):
         """Test magic methods on the fileset examples of the tutorial.
 
         Returns:
 
         """
-        filesets = self.init_filesets()
+        filesets = self.init_filesets(file_system)
         filters = {"satellite": "SatelliteB"}
         result = filesets["tutorial"]["2018-01-01 03:00", filters]
 
@@ -226,13 +273,15 @@ class TestFileSet:
         )
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_tutorial(self):
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_tutorial(self, file_system):
         """Test the fileset examples of the tutorial.
 
         Returns:
             None
         """
-        filesets = self.init_filesets()
+        filesets = self.init_filesets(file_system)
+        refdir = self._refdir_for_fs(file_system)
 
         # STANDARD DATASET
         # Should not find anything:
@@ -253,7 +302,7 @@ class TestFileSet:
         #print("closest check", self._repr_file_info(found_file))
 
         check = FileInfo(
-            join(self.refdir, 'tutorial',
+            join(refdir, 'tutorial',
                  'SatelliteB', '2018-01-01', '000000-050000.nc'),
             [datetime.datetime(2018, 1, 1, 0, 0),
              datetime.datetime(2018, 1, 1, 5, 0)], {'satellite': 'SatelliteB'})
@@ -276,31 +325,31 @@ class TestFileSet:
 
         check = [
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteB', '2018-01-01', '000000-050000.nc'),
                 [datetime.datetime(2018, 1, 1, 0, 0),
                  datetime.datetime(2018, 1, 1, 5, 0)],
                 {'satellite': 'SatelliteB'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteB', '2018-01-01', '050000-100000.nc'),
                 [datetime.datetime(2018, 1, 1, 5, 0),
                  datetime.datetime(2018, 1, 1, 10, 0)],
                 {'satellite': 'SatelliteB'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteB', '2018-01-01', '100000-150000.nc'),
                 [datetime.datetime(2018, 1, 1, 10, 0),
                  datetime.datetime(2018, 1, 1, 15, 0)],
                 {'satellite': 'SatelliteB'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteB', '2018-01-01', '150000-200000.nc'),
                 [datetime.datetime(2018, 1, 1, 15, 0),
                  datetime.datetime(2018, 1, 1, 20, 0)],
                 {'satellite': 'SatelliteB'}),
             FileInfo(
-                join(self.refdir, 'tutorial',
+                join(refdir, 'tutorial',
                      'SatelliteB', '2018-01-01', '200000-010000.nc'),
                 [datetime.datetime(2018, 1, 1, 20, 0),
                  datetime.datetime(2018, 1, 2, 1, 0)],
@@ -321,19 +370,19 @@ class TestFileSet:
         check = [
             [
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '000000-050000.nc'),
                     [datetime.datetime(2018, 1, 1, 0, 0),
                      datetime.datetime(2018, 1, 1, 5, 0)],
                     {'satellite': 'SatelliteB'}),
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '050000-100000.nc'),
                     [datetime.datetime(2018, 1, 1, 5, 0),
                      datetime.datetime(2018, 1, 1, 10, 0)],
                     {'satellite': 'SatelliteB'}),
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '100000-150000.nc'),
                     [datetime.datetime(2018, 1, 1, 10, 0),
                      datetime.datetime(2018, 1, 1, 15, 0)],
@@ -341,13 +390,13 @@ class TestFileSet:
             ],
             [
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '150000-200000.nc'),
                     [datetime.datetime(2018, 1, 1, 15, 0),
                      datetime.datetime(2018, 1, 1, 20, 0)],
                     {'satellite': 'SatelliteB'}),
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '200000-010000.nc'),
                     [datetime.datetime(2018, 1, 1, 20, 0),
                      datetime.datetime(2018, 1, 2, 1, 0)],
@@ -369,19 +418,19 @@ class TestFileSet:
         check = [
             [
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '000000-050000.nc'),
                     [datetime.datetime(2018, 1, 1, 0, 0),
                      datetime.datetime(2018, 1, 1, 5, 0)],
                     {'satellite': 'SatelliteB'}),
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '050000-100000.nc'),
                     [datetime.datetime(2018, 1, 1, 5, 0),
                      datetime.datetime(2018, 1, 1, 10, 0)],
                     {'satellite': 'SatelliteB'}),
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '100000-150000.nc'),
                     [datetime.datetime(2018, 1, 1, 10, 0),
                      datetime.datetime(2018, 1, 1, 15, 0)],
@@ -389,13 +438,13 @@ class TestFileSet:
             ],
             [
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '150000-200000.nc'),
                     [datetime.datetime(2018, 1, 1, 15, 0),
                      datetime.datetime(2018, 1, 1, 20, 0)],
                     {'satellite': 'SatelliteB'}),
                 FileInfo(
-                    join(self.refdir, 'tutorial',
+                    join(refdir, 'tutorial',
                          'SatelliteB', '2018-01-01', '200000-010000.nc'),
                     [datetime.datetime(2018, 1, 1, 20, 0),
                      datetime.datetime(2018, 1, 2, 1, 0)],
@@ -437,17 +486,18 @@ class TestFileSet:
         return data["data"].mean().item(0)
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_files_overlap_subdirectory(self):
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_files_overlap_subdirectory(self, file_system):
         """A file covers a time period longer than its sub directory.
         """
-        filesets = self.init_filesets()
+        filesets = self.init_filesets(file_system)
         filesets["tutorial"].set_placeholders(
             satellite="SatelliteA"
         )
         found_file = filesets["tutorial"].find_closest("2018-01-03")
 
         check = FileInfo(
-            join(self.refdir, 'tutorial',
+            join(self._refdir_for_fs(file_system), 'tutorial',
                  'SatelliteA', '2018-01-02', '200000-000000.nc'),
             [datetime.datetime(2018, 1, 2, 20, 0),
              datetime.datetime(2018, 1, 3, 0, 0)],
@@ -457,13 +507,14 @@ class TestFileSet:
         assert found_file == check
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_single(self):
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_single(self, file_system):
         """Test find on the single fileset.
 
         Returns:
             None
         """
-        filesets = self.init_filesets()
+        filesets = self.init_filesets(file_system)
 
         # STANDARD DATASET
         # Should not find anything:
@@ -474,7 +525,7 @@ class TestFileSet:
         assert not empty
 
         check = [
-            FileInfo(join(self.refdir, 'single_file.nc'),
+            FileInfo(join(self._refdir_for_fs(file_system), 'single_file.nc'),
                      [datetime.datetime(2018, 1, 1, 0, 0),
                       datetime.datetime(2018, 1, 3, 0, 0)], {}),
         ]
@@ -501,13 +552,15 @@ class TestFileSet:
         assert found_files == check
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_sequence(self):
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_sequence(self, file_system):
         """Test find on the sequence filesets.
 
         Returns:
             None
         """
-        filesets = self.init_filesets()
+        filesets = self.init_filesets(file_system)
+        refdir = self._refdir_for_fs(file_system)
 
         # STANDARD DATASET
         # Should not find anything:
@@ -524,11 +577,11 @@ class TestFileSet:
             ))
 
         check = [
-            FileInfo(join(self.refdir, 'sequence',
+            FileInfo(join(refdir, 'sequence',
                           '2018', '001', 'sequence0001.txt'),
                      [datetime.datetime(2018, 1, 1, 0, 0),
                       datetime.datetime(2018, 1, 1, 12, 0)], {'id': 1}),
-            FileInfo(join(self.refdir, 'sequence',
+            FileInfo(join(refdir, 'sequence',
                           '2018', '001', 'sequence0002.txt'),
                      [datetime.datetime(2018, 1, 1, 12, 0),
                       datetime.datetime(2018, 1, 2, 0, 0)], {'id': 2}),
@@ -544,13 +597,13 @@ class TestFileSet:
 
         check = [
             [
-                FileInfo(join(self.refdir, 'sequence',
+                FileInfo(join(refdir, 'sequence',
                               '2018', '001', 'sequence0001.txt'),
                          [datetime.datetime(2018, 1, 1, 0, 0),
                           datetime.datetime(2018, 1, 1, 12, 0)], {'id': 1}),
             ],
             [
-                FileInfo(join(self.refdir, 'sequence',
+                FileInfo(join(refdir, 'sequence',
                               '2018', '001', 'sequence0002.txt'),
                          [datetime.datetime(2018, 1, 1, 12, 0),
                           datetime.datetime(2018, 1, 2, 0, 0)], {'id': 2}),
@@ -559,13 +612,15 @@ class TestFileSet:
         assert found_files == check
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_sequence_placeholder(self):
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_sequence_placeholder(self, file_system):
         """Test find on all standard filesets.
 
         Returns:
             None
         """
-        filesets = self.init_filesets()
+        filesets = self.init_filesets(file_system)
+        refdir = self._refdir_for_fs(file_system)
 
         # STANDARD DATASET
         # Should not find anything:
@@ -582,11 +637,11 @@ class TestFileSet:
             ))
 
         check = [
-            FileInfo(join(self.refdir, 'sequence',
+            FileInfo(join(refdir, 'sequence',
                           '2018', '001', 'sequence0001.txt'),
                      [datetime.datetime(2018, 1, 1, 0, 0),
                       datetime.datetime(2018, 1, 1, 12, 0)], {'id': 1}),
-            FileInfo(join(self.refdir, 'sequence',
+            FileInfo(join(refdir, 'sequence',
                           '2018', '001', 'sequence0002.txt'),
                      [datetime.datetime(2018, 1, 1, 12, 0),
                       datetime.datetime(2018, 1, 2, 0, 0)], {'id': 2}),
@@ -602,13 +657,13 @@ class TestFileSet:
 
         check = [
             [
-                FileInfo(join(self.refdir, 'sequence',
+                FileInfo(join(refdir, 'sequence',
                               '2018', '001', 'sequence0001.txt'),
                          [datetime.datetime(2018, 1, 1, 0, 0),
                           datetime.datetime(2018, 1, 1, 12, 0)], {'id': 1}),
             ],
             [
-                FileInfo(join(self.refdir, 'sequence',
+                FileInfo(join(refdir, 'sequence',
                               '2018', '001', 'sequence0002.txt'),
                          [datetime.datetime(2018, 1, 1, 12, 0),
                           datetime.datetime(2018, 1, 2, 0, 0)], {'id': 2}),
@@ -617,11 +672,12 @@ class TestFileSet:
         assert found_files == check
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_regex(self):
-        filesets = self.init_filesets()
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_regex(self, file_system):
+        filesets = self.init_filesets(file_system)
 
         check = [
-            FileInfo(join(self.refdir, 'regex',
+            FileInfo(join(self._refdir_for_fs(file_system), 'regex',
                           'NSS.HIRX.NJ.D99127.S0632.E0820.B2241718.WI.gz'),
                      [datetime.datetime(1999, 5, 7, 6, 32),
                       datetime.datetime(1999, 5, 7, 8, 20)],
@@ -640,17 +696,20 @@ class TestFileSet:
         assert found_files == check
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    def test_complicated_subdirs(self, ):
+    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    def test_complicated_subdirs(self, file_system):
         """Check whether FileSet can find files in subdirectories that contain
         text and placeholders.
         """
+        refdir = self._refdir_for_fs(file_system)
         # The Pinocchio fileset from the cloud toolbox: a folder name contains
         # normal text and a placeholder:
         pinocchio = FileSet(
-            join(self.refdir, "pinocchio",
+            join(refdir, "pinocchio",
                  "t{year2}{month}{day}",
                  "tm{year2}{month}{day}{hour}{minute}{second}{millisecond}.jpg",
                  ),
+            fs=file_system
         )
 
         # Find all files:
@@ -658,7 +717,7 @@ class TestFileSet:
 
         check = [
             FileInfo(
-                join(self.refdir,
+                join(refdir,
                      'pinocchio', 't171102', 'tm171102132855573.jpg'),
                 [datetime.datetime(2017, 11, 2, 13, 28, 55, 573000),
                  datetime.datetime(2017, 11, 2, 13, 28, 55, 573000)], {}),

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -77,7 +77,7 @@ class TestFileSet:
 
         def sequence_get_info(file_info, **kwargs):
             """Small helper function for sequence fileset."""
-            with open(file_info) as f:
+            with file_info.file_system.open(file_info, mode="rt") as f:
                 file_info.times[0] = datetime.datetime.strptime(
                     f.readline().rstrip(),
                     "Start: %Y-%m-%d %H:%M:%S"
@@ -273,7 +273,7 @@ class TestFileSet:
         )
 
     @pytest.mark.skipif(refdir is None, reason="typhon-testfiles not found.")
-    @pytest.mark.parametrize("file_system", [None, "local", "zip"], indirect=True)
+    @pytest.mark.parametrize("file_system", [None, "local"], indirect=True)
     def test_tutorial(self, file_system):
         """Test the fileset examples of the tutorial.
 


### PR DESCRIPTION
This PR adds partial support for fsspec AbstractFileSystem implementation in FileSet, in particular for finding files.  An example using `sf3s`:

```python
import s3fs
from typhon.files.fileset import FileSet
abi_fileset = FileSet(
        path="noaa-goes16/ABI-L1b-RadF/{year}/{doy}/{hour}/OR_ABI-L1b-RadF-M6C02_G16_s{year}{doy}{hour}{minute}{second}*_e{end_year}{end_doy}{end_hour}{end_minute}{end_second}*_c*.nc",                                                                                                 
        name="abi",
        fs=s3fs.S3FileSystem(anon=True))
for f in abi_fileset.find("2019-11-18T05:30", "2019-11-18T06:15"):
    print(f)
```

Gives:

```
noaa-goes16/ABI-L1b-RadF/2019/322/05/OR_ABI-L1b-RadF-M6C02_G16_s20193220530285_e20193220539593_c20193220540030.nc
noaa-goes16/ABI-L1b-RadF/2019/322/05/OR_ABI-L1b-RadF-M6C02_G16_s20193220540285_e20193220549593_c20193220550041.nc
noaa-goes16/ABI-L1b-RadF/2019/322/05/OR_ABI-L1b-RadF-M6C02_G16_s20193220550285_e20193220559593_c20193220600041.nc
noaa-goes16/ABI-L1b-RadF/2019/322/06/OR_ABI-L1b-RadF-M6C02_G16_s20193220600285_e20193220609593_c20193220610030.nc
noaa-goes16/ABI-L1b-RadF/2019/322/06/OR_ABI-L1b-RadF-M6C02_G16_s20193220610285_e20193220619593_c20193220620040.nc
```

- [x] Closes #373 
- [x] Tests added
- [ ] Tests passed
- [x] Documentation added