### PR TITLE
Don't fail comparing FileInfo to other type

### DIFF
--- a/typhon/files/handlers/common.py
+++ b/typhon/files/handlers/common.py
@@ -306,7 +306,9 @@ class FileInfo(os.PathLike):
             self.attr = attr
 
     def __eq__(self, other):
-        return self.path == other.path and self.times == other.times
+        return (isinstance(other, type(self))
+                and self.path == other.path
+                and self.times == other.times)
 
     def __fspath__(self):
         return self.path

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -710,3 +710,33 @@ class TestFileSet:
         return "FileInfo(\n\t{}, \t{}, \t{}),".format(
             path, repr(file_info.times), repr(file_info.attr)
         )
+
+    def test_compare_fileinfo(self):
+        """Test comparing two FileInfo instances."""
+        f1 = FileInfo(
+                path="fake/path",
+                times=[datetime.datetime(1900, 1, 1, 0),
+                       datetime.datetime(1900, 1, 1, 2)],
+                attr={})
+        f2 = FileInfo(
+                path="fake/path",
+                times=[datetime.datetime(1900, 1, 1, 0),
+                       datetime.datetime(1900, 1, 1, 2)],
+                attr={})
+        f3 = FileInfo(
+                path="other/fake/path",
+                times=[datetime.datetime(1900, 1, 1, 0),
+                       datetime.datetime(1900, 1, 1, 2)],
+                attr={})
+        f4 = FileInfo(
+                path="fake/path",
+                times=[datetime.datetime(1910, 1, 1, 0),
+                       datetime.datetime(1910, 1, 1, 2)],
+                attr={})
+        assert f1 == f2
+        assert f1 != f3
+        assert f1 != f4
+        assert f2 != f3
+        assert f2 != f4
+        assert f3 != f4
+        assert f1 != "fake/path"


### PR DESCRIPTION
Don't fail with an AttributeError when comparing a FileInfo instance to
a string.  Equality operations shouldn't fail, rather then the other has
a different type then the result of the equality should simply be a
negative.

Also adds some unit tests for FileInfo comparisons.