### PR TITLE
Fix broken matplotlib tests

### DIFF
--- a/typhon/plots/plots.py
+++ b/typhon/plots/plots.py
@@ -526,7 +526,7 @@ def profile_p(p, x, ax=None, **kwargs):
 
     # Label and format for yaxis.
     formatter.set_yaxis_formatter(formatter.HectoPascalFormatter(), ax=ax)
-    if ax.is_first_col():
+    if ax.get_subplotspec().is_first_col():
         ax.set_ylabel('Pressure [hPa]')
 
     # Actual plot.

--- a/typhon/tests/plots/test_colors.py
+++ b/typhon/tests/plots/test_colors.py
@@ -87,22 +87,24 @@ class TestColors:
 
     def test_cmap_from_txt(self):
         """Import colormap from txt file."""
-        viridis = plt.get_cmap('viridis')
-        cmap = colors.cmap_from_txt(os.path.join(self.ref_dir, 'viridis.txt'))
-
-        plt.register_cmap(cmap=viridis)  # Register original viridis.
-
         idx = np.linspace(0, 1, 256)
+
+        viridis = plt.get_cmap('viridis')
+
+        cmap = colors.cmap_from_txt(os.path.join(
+            self.ref_dir, 'viridis.txt'), name="viridis_read")
+
         assert np.allclose(viridis(idx), cmap(idx), atol=0.001)
 
     def test_cmap_from_act(self):
         """Import colormap from act file."""
-        viridis = plt.get_cmap('viridis')
-        cmap = colors.cmap_from_act(os.path.join(self.ref_dir, 'viridis.act'))
-
-        plt.register_cmap(cmap=viridis)  # Register original viridis.
-
         idx = np.linspace(0, 1, 256)
+
+        viridis = plt.get_cmap('viridis')
+
+        cmap = colors.cmap_from_act(
+            os.path.join(self.ref_dir, 'viridis.act'), name="viridis_read")
+
         assert np.allclose(viridis(idx), cmap(idx), atol=0.004)
 
     def test_get_material_design(self):


### PR DESCRIPTION
This PR
1. fixes a bug related to re-registration of colormaps which becomes illegal in Matplotlib >3.4.2
2. silences a deprecation warning when checking for relative axis location in a subplot

Point 1 raises the question if `cmap_from_{act,txt}` should register the colormap. A possible option is to only return the colormap instance. This might cause some minor changes to the way we are loading the Typhon colormaps (need to register the colormaps there).