### PR TITLE
Remove group prefix from coords variable names

### DIFF
--- a/typhon/collocations/collocator.py
+++ b/typhon/collocations/collocator.py
@@ -321,9 +321,10 @@ class Collocator:
         elapsed_time -= timedelta(microseconds=elapsed_time.microseconds)
         if len(process_progress) == 0:
             msg = "-"*79 + "\n"
-            msg += f"100% | {elapsed_time} hours elapsed | " \
-                   f"{errors} processes failed\n"
-            msg += "-"*79 + "\n"
+            msg += f"100% | {elapsed_time} hours elapsed"
+            if errors != "unknown":
+                msg += f" | {errors} failed"
+            msg += "\n" + "-"*79 + "\n"
             logger.error(msg)
             return
 
@@ -338,9 +339,10 @@ class Collocator:
 
         msg = "-"*79 + "\n"
         msg += f"{progress:.0f}% | {elapsed_time} hours elapsed, " \
-               f"{expected_time} hours left | {processes} proc running, " \
-               f"{errors} failed\n"
-        msg += "-"*79 + "\n"
+               f"{expected_time} hours left | {processes} proc running"
+        if errors != "unknown":
+            msg += f", {errors} failed"
+        msg += "\n" + "-"*79 + "\n"
         logger.error(msg)
 
     @staticmethod

--- a/typhon/files/handlers/common.py
+++ b/typhon/files/handlers/common.py
@@ -812,6 +812,11 @@ class NetCDF4(FileHandler):
             }
             ds = ds.rename(mapping)
             mapping = {
+                full: NetCDF4._split_path(full)[1]
+                for full in ds.coords
+            }
+            ds = ds.rename(mapping)
+            mapping = {
                 dim: NetCDF4._split_path(dim)[1]
                 for dim in ds.dims
             }


### PR DESCRIPTION
Like for common variables, before saving the coords variables to the
netCDF file, the group prefix has to be removed from their names.

Fixes error reported by Bruno Picard when saving data generated by
Collocations.search from primary/secondary datasets containing
coord variables.