### PR TITLE
Use the constrained figure layout by default

### DIFF
--- a/typhon/plots/stylelib/typhon-constrained.mplstyle
+++ b/typhon/plots/stylelib/typhon-constrained.mplstyle
@@ -1,2 +1,0 @@
-## Figure layout
-figure.constrained_layout.use: True

--- a/typhon/plots/stylelib/typhon-tight.mplstyle
+++ b/typhon/plots/stylelib/typhon-tight.mplstyle
@@ -1,2 +1,0 @@
-## Figure layout
-figure.autolayout : True

--- a/typhon/plots/stylelib/typhon.mplstyle
+++ b/typhon/plots/stylelib/typhon.mplstyle
@@ -50,6 +50,7 @@ legend.fontsize : small
 # See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
 figure.figsize : 10, 6.18 # figure size in inches
 figure.titlesize : large # same as axes.titlesize
+figure.constrained_layout.use: True
 
 ### SAVING FIGURES
 savefig.dpi: 144  # dots per inches


### PR DESCRIPTION
This PR
* sets the [constrained layout](https://matplotlib.org/stable/tutorials/intermediate/constrainedlayout_guide.html) as default for the `typhon` style
* removes the `typhon-constrained` and `typhon-tight` matplotlib stylesheets