### PR TITLE
Replace deprecated first-column check

### DIFF
--- a/typhon/plots/plots.py
+++ b/typhon/plots/plots.py
@@ -638,7 +638,7 @@ def profile_z(z, x, ax=None, **kwargs):
     ax.set_ylim(zmin, zmax)
 
     # Label and format for yaxis.
-    if ax.is_first_col():
+    if ax.get_subplotspec().is_first_col():
         ax.set_ylabel('Height [km]')
 
     # Actual plot.


### PR DESCRIPTION
Even though the usage of `ax.is_first_col()` within the function `plot_profile_z` does not trigger the deprecation warning - for reasons unknown - we should replace it with the future proof call.