### PR TITLE
Add filehandler for remote netcdf reading

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
         - cython
         - fsspec
         - gdal
+        - h5netcdf
         - keras
         - matplotlib>=1.4
         - netCDF4>=1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cartopy
 cython
 fsspec
 gdal
+h5netcdf
 keras
 matplotlib>=1.4
 nbsphinx

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     install_requires=[
         "docutils",
         "fsspec",
+        "h5netcdf",
         "imageio",
         "matplotlib>=1.4",
         "netCDF4>=1.1.1",

--- a/typhon/files/handlers/common.py
+++ b/typhon/files/handlers/common.py
@@ -850,6 +850,19 @@ class FSNetCDF(FileHandler):
     Alternative to the NetCDF file handler for reading files from
     alternative file systems, such as remote file systemss.  Does not
     support writing or multi-group files.
+
+    Usage example with fileset::
+
+        fs = FileSet(
+                path=(
+                    "noaa-goes16/GLM-L2-LCFA/{year}/{doy}/{hour}/"
+                    "OR_GLM-L2-LCFA_G16_s{year}{doy}{hour}{minute}{second}*_"
+                    "e{end_year}{end_doy}{end_hour}{end_minute}{end_second}*_c*.nc"),
+                fs=s3fs.S3FileSystem(anon=True),
+                handler=FSNetCDF())
+
+        finf = fs.find_closest(datetime.datetime(2021, 11, 10, 10))
+        fs.read(finf)
     """
 
     def __init__(self, *args, **kwargs):

--- a/typhon/files/handlers/common.py
+++ b/typhon/files/handlers/common.py
@@ -835,6 +835,43 @@ class NetCDF4(FileHandler):
             return None, path
         return path.rsplit("/", 1)
 
+    def _ensure_local_filesystem(self, file_info):
+        if not isinstance(file_info.file_system, LocalFileSystem):
+            raise NotImplementedError(
+                    f"File handler {type(self).__name__:s} can only "
+                    "read from local file system, not from "
+                    f"{str(type(file_info.file_system).__name__)}. "
+                    "Use FSNetCDF instead.")
+
+
+class FSNetCDF(FileHandler):
+    """File handler for reading NetCDF files via alternate file systems.
+
+    Alternative to the NetCDF file handler for reading files from
+    alternative file systems, such as remote file systemss.  Does not
+    support writing or multi-group files.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._open = []
+
+    @expects_file_info()
+    def read(self, file_info, fields=None, mapping=None, **kwargs):
+        """Read possibly remote NetCDF file."""
+        fp = file_info.file_system.open(file_info.path)
+        ds = xr.open_dataset(fp, engine="h5netcdf")
+        self._open.append(ds)
+        return ds
+
+    def close_all(self):
+        """Close all open files."""
+        while self._open:
+            self._open.pop(0).close()
+
+    def __del__(self):
+        self.close_all()
+
 
 class Plotter(FileHandler):
     """File handler that can save matplotlib.figure objects to a file.


### PR DESCRIPTION
Add a filehandler that can work with filesystem implementations and therefore with remote file systems.

Closes #395.