### PR TITLE
Add 3.10, remove 3.7

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu, windows, macos]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
         include:
           - name: ubuntu
@@ -44,7 +44,7 @@ jobs:
           pip install .
 
       - name: Lint with flake8 (Linux)
-        if: runner.os == 'Linux' && matrix.python-version == '3.7'
+        if: runner.os == 'Linux' && matrix.python-version == '3.8'
         continue-on-error: true
         run: |
           pip install flake8

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu, windows, macos]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
         include:
           - name: ubuntu

--- a/conda/conda.recipe/meta.yaml
+++ b/conda/conda.recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.8
     - pip
     - setuptools >=3.4
   run:

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: typhon
 dependencies:
-        - python>=3.7
+        - python>=3.8
         - cartopy
         - cython
         - fsspec

--- a/setup.py
+++ b/setup.py
@@ -71,11 +71,11 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Atmospheric Science",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
-    python_requires="~=3.7",
+    python_requires="~=3.8",
     include_package_data=True,
     install_requires=[
         "docutils",


### PR DESCRIPTION
Add Python 3.10 to CI and remove Python 3.7.  This is consistent with
many other scientific Python packages, which follow NEP 29 at
https://numpy.org/neps/nep-0029-deprecation_policy.html.  According to
NEP 29, minor versions of Python can be dropped 42 months after release.
For Python 3.7, this date passed 2021-12-26.  The last bugfix release for Python 3.7 was 2020-06-27.

Python 3.10 was released 2021-10-04.  As shown on
https://conda-forge.org/status/#python310, all major 3rd party libraries,
including all typhon dependents, have built packages for Python 3.10.