### PR TITLE
correct unit of gravitational acceleration

### DIFF
--- a/typhon/constants.py
+++ b/typhon/constants.py
@@ -5,7 +5,7 @@ Physical constants
 ==================
 
 =============================== ==============================================
-``g``                           Earth standard gravity in :math:`\sf ms^{-1}`
+``g``                           Earth standard gravity in :math:`\sf ms^{-2}`
 ``h``                           Planck constant in :math:`\sf Js`
 ``k``                           Boltzmann constant in :math:`\sf JK^{-1}`
 ``c``                           Speed of light in :math:`\sf ms^{-1}`


### PR DESCRIPTION
This is a simple change in documentation.

Unit of gravitational acceleration corrected to `ms^{-2}` from `ms^{-1}`