### PR TITLE
Fix test issues

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
 
         include:
           - name: ubuntu
-            os: ubuntu-18.04
+            os: ubuntu-latest
 
           - name: windows
             os: windows-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,5 +62,6 @@ jobs:
       - name: Test (Windows)
         if: runner.os == 'Windows'
         run: |
+          $Env:HDF5_DISABLE_VERSION_CHECK = 1
           $Env:TYPHONTESTFILES = Join-Path $pwd "typhon-testfiles"
           pytest --pyargs typhon

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -1,11 +1,9 @@
 import os
-from os.path import dirname
 from posixpath import join  # LocalFileSystem always uses /
 
 import datetime
 import numpy as np
 import pytest
-import shutil
 import logging
 
 from typhon.files import FileHandler, FileInfo, FileSet, FileSetManager

--- a/typhon/tests/files/test_fileset.py
+++ b/typhon/tests/files/test_fileset.py
@@ -30,8 +30,10 @@ class TestFileSet:
             from shutil import make_archive
             # prepare archive to test on
             archive = tmp_path / "test"
-            shutil.make_archive(
-                    archive, "zip", os.curdir, self.refdir)
+            make_archive(
+                archive, "zip", "/" if os.path.isabs(self.refdir) else os.curdir,
+                self.refdir)
+
             return ZipFileSystem(archive.with_suffix(".zip"))
         elif request.param == "local":
             from fsspec.implementations.local import LocalFileSystem

--- a/typhon/tests/plots/test_colors.py
+++ b/typhon/tests/plots/test_colors.py
@@ -92,7 +92,7 @@ class TestColors:
         viridis = plt.get_cmap('viridis')
 
         cmap = colors.cmap_from_txt(os.path.join(
-            self.ref_dir, 'viridis.txt'), name="viridis_read")
+            self.ref_dir, 'viridis.txt'), name="viridis_read_txt")
 
         assert np.allclose(viridis(idx), cmap(idx), atol=0.001)
 
@@ -103,7 +103,7 @@ class TestColors:
         viridis = plt.get_cmap('viridis')
 
         cmap = colors.cmap_from_act(
-            os.path.join(self.ref_dir, 'viridis.act'), name="viridis_read")
+            os.path.join(self.ref_dir, 'viridis.act'), name="viridis_read_act")
 
         assert np.allclose(viridis(idx), cmap(idx), atol=0.004)
 


### PR DESCRIPTION
Fix for breaking change in matplotlib 3.6.
Fix root_dir for make_archive in test_fileset.
Ignore HDF header / library inconsistency error on Windows.