### PR TITLE
Make numba optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
         "imageio",
         "matplotlib>=1.4",
         "netCDF4>=1.1.1",
-        "numba",
         "numexpr",
         "numpy>=1.13",
         "pandas",

--- a/typhon/collocations/collocator.py
+++ b/typhon/collocations/collocator.py
@@ -212,7 +212,7 @@ class Collocator:
         # match, the process pushes its results to the result queue. If errors
         # are raised during collocating, the raised errors are pushed to the
         # error queue,
-        matches_chunks = np.array_split(matches, processes)
+        matches_chunks = np.array_split(np.array(matches, dtype=object), processes)
 
         # This queue collects all results:
         results = Queue(maxsize=processes)

--- a/typhon/collocations/common.py
+++ b/typhon/collocations/common.py
@@ -328,7 +328,7 @@ def collapse(data, reference=None, collapser=None):
         if _has_numba:
             rows_in_bins = _rows_for_secondaries_numba(primary_indices)
         else:
-            warn("Consider installing numba for better performance", UserWarning, stacklevel=2)
+            warn("Consider installing numba for better performance", UserWarning)
             rows_in_bins = _rows_for_secondaries(primary_indices)
     #    print(f"{time.time()-timer:.2f} seconds for numba")
 

--- a/typhon/nonlte/rtc/__init__.py
+++ b/typhon/nonlte/rtc/__init__.py
@@ -1,11 +1,14 @@
 
-import numba
+try:
+    import numba
+    _has_numba = True
+except ImportError:
+    _has_numba = False
 
 import numpy as np
 from ..spectra.source_function import Bv_T, PopuSource_AB
 from ..spectra.abscoeff import basic
 
-@numba.jit
 def FOSC(tau, Sb, Sm, Ib):
     """ First Order Short Characteristics 
 
@@ -32,6 +35,10 @@ def FOSC(tau, Sb, Sm, Ib):
     Im = Ib * np.exp(-tau) + lambda_m * Sm + lambda_b * Sb  # (12.114)
     Im[tau == 0] = Ib[tau == 0]
     return Im, lambda_m
+
+
+if _has_numba:
+    FOSC = numba.jit(FOSC)
 
 
 def SOSC(tau1, tau3, S1, S2, S3, I1):

--- a/typhon/trees.py
+++ b/typhon/trees.py
@@ -8,7 +8,6 @@ performing query requests on them significantly.
 from collections.abc import Iterable
 
 import pandas as pd
-# import numba
 import numpy as np
 
 from sklearn.neighbors import BallTree, KDTree
@@ -79,7 +78,6 @@ class IntervalTree:
         else:
             return bool(self._query_point(item, self.root, check_extreme=True))
 
-    # @numba.jit
     def _build_tree(self, intervals):
         if not intervals.any():
             return None
@@ -130,7 +128,6 @@ class IntervalTree:
         """
         return interval[0] <= point <= interval[1]
 
-    # @numba.jit
     def query(self, intervals):
         """Find all overlaps between this tree and a list of intervals.
 
@@ -145,7 +142,6 @@ class IntervalTree:
         return [self._query(interval, self.root, check_extreme=True)
                 for interval in intervals]
 
-    # @numba.jit
     def _query(self, query_interval, node, check_extreme=False):
         # Check this special case: the bounds of the query interval lie outside
         # of the bounds of this tree:
@@ -166,7 +162,6 @@ class IntervalTree:
 
         return intervals
 
-    # @numba.jit
     def query_points(self, points):
         """Find all intervals of this tree which contain one of those points.
 
@@ -180,7 +175,6 @@ class IntervalTree:
         return [self._query_point(point, self.root, check_extreme=True)
                 for point in points]
 
-    # @numba.jit
     def _query_point(self, point, node, check_extreme=False):
         # Check this special case: the query point lies outside of the bounds
         # of this tree:

--- a/typhon/trees.py
+++ b/typhon/trees.py
@@ -8,7 +8,7 @@ performing query requests on them significantly.
 from collections.abc import Iterable
 
 import pandas as pd
-import numba
+# import numba
 import numpy as np
 
 from sklearn.neighbors import BallTree, KDTree


### PR DESCRIPTION
Numba takes a long time to be updated for newer numpy and Python versions. It does neither support [numpy 1.24](https://github.com/numba/numba/issues/8464) nor [Python 3.11](https://github.com/numba/numba/issues/8304) yet and thus prevents typhon from being installed in environments that require these versions.

This PR changes numba to be used if available, but not have a hard dependency on it.