### PR TITLE
Remove Python 3.8 support, add Python 3.11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu, windows, macos]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
         include:
           - name: ubuntu

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: typhon
 dependencies:
-        - python>=3.8
+        - python>=3.9
         - cartopy
         - cython
         - fsspec

--- a/environment.yml
+++ b/environment.yml
@@ -25,5 +25,4 @@ dependencies:
         - sphinx_rtd_theme
         - xarray>=0.10.2
 channels:
-        - defaults
         - conda-forge

--- a/setup.py
+++ b/setup.py
@@ -71,11 +71,11 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Atmospheric Science",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
-    python_requires="~=3.8",
+    python_requires="~=3.9",
     include_package_data=True,
     install_requires=[
         "docutils",


### PR DESCRIPTION
Needs #414 to be merged for the Python 3.11 tests to succeed.