### PR TITLE
Require matplotlib <3.9

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
         - gdal
         - h5netcdf
         - keras
-        - matplotlib>=1.4
+        - matplotlib>=1.4,<3.9
         - netCDF4>=1.1.1
         - nbsphinx
         - numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ fsspec!=2023.12.0,!=2023.12.1,!=2024.3.1
 gdal
 h5netcdf
 keras
-matplotlib>=1.4
+matplotlib>=1.4,<3.9
 nbsphinx
 netCDF4>=1.1.1
 numba

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "fsspec!=2023.12.0,!=2023.12.1,!=2024.3.1",
         "h5netcdf",
         "imageio",
-        "matplotlib>=1.4",
+        "matplotlib>=1.4,<3.9",
         "netCDF4>=1.1.1",
         "numexpr",
         "numpy>=1.13",


### PR DESCRIPTION
Fix failing tests. Proper fix to make typhon matplotlib 3.9 compatible will be done in a separate PR.